### PR TITLE
Adds follow event triggers, and fixes eventsub types

### DIFF
--- a/internal/events/follow_event.go
+++ b/internal/events/follow_event.go
@@ -1,0 +1,93 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package trigger
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
+)
+
+type FollowParams struct {
+	Transport string
+	FromUser  string
+	ToUser    string
+	Type      string
+}
+
+func GenerateFollowBody(p FollowParams) (TriggerResponse, error) {
+	uuid := util.RandomGUID()
+	var event []byte
+	var err error
+
+	fromUserName := "testFromuser"
+
+	toUserName := "testBroadcaster"
+
+	if p.ToUser == "" {
+		p.ToUser = util.RandomUserID()
+	}
+
+	if p.FromUser == "" {
+		p.FromUser = util.RandomUserID()
+	}
+
+	switch p.Transport {
+	case "eventsub":
+		body := models.EventsubResponse{
+			Subscription: models.EventsubSubscription{
+				ID:      uuid,
+				Type:    p.Type,
+				Version: "test",
+				Condition: models.EventsubCondition{
+					BroadcasterUserID: p.ToUser,
+				},
+				Transport: models.EventsubTransport{
+					Method:   "eventsub",
+					Callback: "null",
+				},
+				CreatedAt: util.GetTimestamp().Format(time.RFC3339),
+			},
+			Event: models.FollowEventSubEvent{
+				UserID:              p.FromUser,
+				UserName:            fromUserName,
+				BroadcasterUserID:   p.ToUser,
+				BroadcasterUserName: toUserName,
+			},
+		}
+
+		event, err = json.Marshal(body)
+		if err != nil {
+			return TriggerResponse{}, err
+		}
+
+	case "websub":
+		body := models.FollowWebSubResponse{
+			Data: []models.FollowWebSubResponseData{
+				{
+					FromID:     p.FromUser,
+					FromName:   fromUserName,
+					ToID:       p.ToUser,
+					ToName:     toUserName,
+					FollowedAt: util.GetTimestamp().Format(time.RFC3339),
+				},
+			},
+		}
+		event, err = json.Marshal(body)
+		if err != nil {
+			return TriggerResponse{}, err
+		}
+
+	default:
+		return TriggerResponse{}, nil
+	}
+
+	return TriggerResponse{
+		ID:       uuid,
+		JSON:     event,
+		FromUser: p.FromUser,
+		ToUser:   p.ToUser,
+	}, nil
+}

--- a/internal/events/models.go
+++ b/internal/events/models.go
@@ -4,11 +4,11 @@ package trigger
 
 var triggerTypeMap = map[string]map[string]string{
 	"eventsub": {
-		"cheer":       "channels.cheer",
-		"subscribe":   "channels.subscribe",
-		"unsubscribe": "channels.unsubscribe",
-		"gift":        "channels.subscribe",
-		"follow":      "users.follow",
+		"cheer":       "channel.cheer",
+		"subscribe":   "channel.subscribe",
+		"unsubscribe": "channel.unsubscribe",
+		"gift":        "channel.subscribe",
+		"follow":      "channel.follow",
 		"transaction": "",
 	},
 	"websub": {
@@ -20,11 +20,11 @@ var triggerTypeMap = map[string]map[string]string{
 		"transaction": "transaction",
 	},
 	"websockets": {
-		"cheer":       "channels.cheer",
-		"subscribe":   "channels.subscribe",
-		"unsubscribe": "channels.unsubscribe",
-		"gift":        "channels.subscribe",
-		"follow":      "users.follow",
+		"cheer":       "channel.cheer",
+		"subscribe":   "channel.subscribe",
+		"unsubscribe": "channel.unsubscribe",
+		"gift":        "channel.subscribe",
+		"follow":      "channel.follow",
 		"transaction": "",
 	},
 }
@@ -35,7 +35,7 @@ var triggerSupported = map[string]bool{
 	"gift":        true,
 	"cheer":       true,
 	"transaction": true,
-	"follow":      false,
+	"follow":      true,
 }
 
 var transportSupported = map[string]bool{

--- a/internal/events/trigger_event.go
+++ b/internal/events/trigger_event.go
@@ -75,6 +75,14 @@ func Fire(p TriggerParamaters) (string, error) {
 			IsAnonymous: p.IsAnonymous,
 		})
 
+	case "follow":
+		resp, err = GenerateFollowBody(FollowParams{
+			Type:      event,
+			Transport: p.Transport,
+			FromUser:  p.FromUser,
+			ToUser:    p.ToUser,
+		})
+
 	case "transaction":
 		resp, err = GenerateTransactionBody(TransactionParams{
 			Transport: p.Transport,

--- a/internal/models/follow.go
+++ b/internal/models/follow.go
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package models
+
+type FollowEventSubEvent struct {
+	UserID              string `json:"user_id"`
+	UserName            string `json:"user_name"`
+	BroadcasterUserID   string `json:"broadcaster_user_id"`
+	BroadcasterUserName string `json:"broadcaster_user_name"`
+}
+
+type FollowWebSubResponse struct {
+	Data []FollowWebSubResponseData `json:"data"`
+}
+
+type FollowWebSubResponseData struct {
+	FromID     string `json:"from_id"`
+	FromName   string `json:"from_name"`
+	ToID       string `json:"to_id"`
+	ToName     string `json:"to_name"`
+	FollowedAt string `json:"followed_at"`
+}


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Please include a description of the problem or feature this PR is addressing.

## Description of Changes: 

- Adds support for the `follow` event.
- The eventsub types used `channels` as a plural, which isn't consistent with the subscription types defined in the [documentation](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types), I've made these consistent with the types defined on the documentation.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)

^ This one does make a breaking change, but equally the breaking change makes the eventsub payload actually useful to use the `subscription.type` from in mock events, as this wasn't correct with what eventsub actually supports.

- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
