### PR TITLE
adding login to eventsub events per recent update

### DIFF
--- a/internal/events/cheer_event.go
+++ b/internal/events/cheer_event.go
@@ -60,12 +60,14 @@ func GenerateCheerBody(p CheerParams) (TriggerResponse, error) {
 				CreatedAt: util.GetTimestamp().Format(time.RFC3339),
 			},
 			Event: models.CheerEventSubEvent{
-				UserID:              p.FromUser,
-				UserName:            toUserName,
-				BroadcasterUserID:   p.ToUser,
-				BroadcasterUserName: fromUserName,
-				IsAnonymous:         p.IsAnonymous,
-				Bits:                100,
+				UserID:               p.FromUser,
+				UserLogin:            toUserName,
+				UserName:             toUserName,
+				BroadcasterUserID:    p.ToUser,
+				BroadcasterUserLogin: fromUserName,
+				BroadcasterUserName:  fromUserName,
+				IsAnonymous:          p.IsAnonymous,
+				Bits:                 100,
 			},
 		}
 

--- a/internal/events/cheer_event.go
+++ b/internal/events/cheer_event.go
@@ -18,7 +18,7 @@ type CheerParams struct {
 	ToUser      string
 	FromUser    string
 	Message     string
-	Bits        float64
+	Bits        int64
 }
 
 func GenerateCheerBody(p CheerParams) (TriggerResponse, error) {
@@ -41,6 +41,10 @@ func GenerateCheerBody(p CheerParams) (TriggerResponse, error) {
 	if p.IsAnonymous == true {
 		p.FromUser = ""
 		fromUserName = ""
+	}
+
+	if p.Bits <= 0 {
+		p.Bits = 100
 	}
 
 	switch p.Transport {
@@ -67,7 +71,8 @@ func GenerateCheerBody(p CheerParams) (TriggerResponse, error) {
 				BroadcasterUserLogin: fromUserName,
 				BroadcasterUserName:  fromUserName,
 				IsAnonymous:          p.IsAnonymous,
-				Bits:                 100,
+				Message:              "This is a test event.",
+				Bits:                 p.Bits,
 			},
 		}
 

--- a/internal/events/follow_event.go
+++ b/internal/events/follow_event.go
@@ -51,10 +51,12 @@ func GenerateFollowBody(p FollowParams) (TriggerResponse, error) {
 				CreatedAt: util.GetTimestamp().Format(time.RFC3339),
 			},
 			Event: models.FollowEventSubEvent{
-				UserID:              p.FromUser,
-				UserName:            fromUserName,
-				BroadcasterUserID:   p.ToUser,
-				BroadcasterUserName: toUserName,
+				UserID:               p.FromUser,
+				UserLogin:            fromUserName,
+				UserName:             fromUserName,
+				BroadcasterUserID:    p.ToUser,
+				BroadcasterUserLogin: toUserName,
+				BroadcasterUserName:  toUserName,
 			},
 		}
 

--- a/internal/events/redemption_event.go
+++ b/internal/events/redemption_event.go
@@ -19,7 +19,7 @@ type RedemptionParams struct {
 	Title     string
 	Prompt    string
 	Status    string
-	RewardId  string
+	RewardID  string
 	Cost      int64
 }
 
@@ -54,8 +54,8 @@ func GenerateRedemptionBody(p RedemptionParams) (TriggerResponse, error) {
 		p.Status = "unfulfilled"
 	}
 
-	if p.RewardId == "" {
-		p.RewardId = util.RandomGUID()
+	if p.RewardID == "" {
+		p.RewardID = util.RandomGUID()
 	}
 
 	if p.Cost <= 0 {
@@ -79,15 +79,17 @@ func GenerateRedemptionBody(p RedemptionParams) (TriggerResponse, error) {
 				CreatedAt: tNow,
 			},
 			Event: models.RedemptionEventSubEvent{
-				Id:                  uuid,
-				BroadcasterUserId:   p.ToUser,
-				BroadcasterUserName: toUserName,
-				UserId:              p.FromUser,
-				UserName:            fromUserName,
-				UserInput:           "Test Input From CLI",
-				Status:              p.Status,
+				ID:                   uuid,
+				BroadcasterUserID:    p.ToUser,
+				BroadcasterUserLogin: toUserName,
+				BroadcasterUserName:  toUserName,
+				UserID:               p.FromUser,
+				UserLogin:            fromUserName,
+				UserName:             fromUserName,
+				UserInput:            "Test Input From CLI",
+				Status:               p.Status,
 				Reward: models.RedemptionReward{
-					Id:     p.RewardId,
+					ID:     p.RewardID,
 					Title:  p.Title,
 					Cost:   p.Cost,
 					Prompt: p.Prompt,

--- a/internal/events/redemption_event_test.go
+++ b/internal/events/redemption_event_test.go
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-IDentifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 package trigger
 
 import (

--- a/internal/events/redemption_event_test.go
+++ b/internal/events/redemption_event_test.go
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-IDentifier: Apache-2.0
 package trigger
 
 import (
@@ -18,7 +18,7 @@ func TestEventsubRedemption(t *testing.T) {
 		Title:     "Test Title",
 		Prompt:    "Test Prompt",
 		Status:    "tested",
-		RewardId:  "12345678-1234-abcd-5678-000000000000",
+		RewardID:  "12345678-1234-abcd-5678-000000000000",
 		Cost:      1337,
 	}
 
@@ -32,12 +32,12 @@ func TestEventsubRedemption(t *testing.T) {
 		t.Error("Error unmarshalling JSON")
 	}
 
-	if body.Event.BroadcasterUserId != toUser {
-		t.Errorf("Expected to user %v, got %v", toUser, body.Event.BroadcasterUserId)
+	if body.Event.BroadcasterUserID != toUser {
+		t.Errorf("Expected to user %v, got %v", toUser, body.Event.BroadcasterUserID)
 	}
 
-	if body.Event.UserId != fromUser {
-		t.Errorf("Expected from user %v, got %v", r.ToUser, body.Event.UserId)
+	if body.Event.UserID != fromUser {
+		t.Errorf("Expected from user %v, got %v", r.ToUser, body.Event.UserID)
 	}
 
 	if body.Event.Status != "tested" {
@@ -48,7 +48,7 @@ func TestEventsubRedemption(t *testing.T) {
 		t.Errorf("Expected reward cost 1337, got %v", body.Event.Reward.Cost)
 	}
 
-	if body.Event.Reward.Id != "12345678-1234-abcd-5678-000000000000" {
-		t.Errorf("Expected reward cost 12345678-1234-abcd-5678-00000000000, got %v", body.Event.Reward.Id)
+	if body.Event.Reward.ID != "12345678-1234-abcd-5678-000000000000" {
+		t.Errorf("Expected reward cost 12345678-1234-abcd-5678-00000000000, got %v", body.Event.Reward.ID)
 	}
 }

--- a/internal/events/reward_event.go
+++ b/internal/events/reward_event.go
@@ -62,8 +62,9 @@ func GenerateRewardBody(p RewardParams) (TriggerResponse, error) {
 				CreatedAt: tNow,
 			},
 			Event: models.RewardEventSubEvent{
-				Id:                                uuid,
-				BroadcasterUserId:                 p.ToUser,
+				ID:                                uuid,
+				BroadcasterUserID:                 p.ToUser,
+				BroadcasterUserLogin:              toUserName,
 				BroadcasterUserName:               toUserName,
 				IsEnabled:                         true,
 				IsPaused:                          false,
@@ -75,28 +76,28 @@ func GenerateRewardBody(p RewardParams) (TriggerResponse, error) {
 				ShouldRedemptionsSkipRequestQueue: false,
 				CooldownExpiresAt:                 tNow,
 				RedemptionsRedeemedCurrentStream:  0,
-				MaxPerStream:                      models.RewardMax{
+				MaxPerStream: models.RewardMax{
 					IsEnabled: true,
 					Value:     100,
 				},
-				MaxPerUserPerStream:               models.RewardMax{
+				MaxPerUserPerStream: models.RewardMax{
 					IsEnabled: true,
 					Value:     100,
 				},
-				GlobalCooldown:                    models.RewardGlobalCooldown{
+				GlobalCooldown: models.RewardGlobalCooldown{
 					IsEnabled: true,
 					Value:     300,
 				},
-				BackgroundColor:                   "#c0ffee",
-				Image:                             models.RewardImage{
-					Url1x: "https://static-cdn.jtvnw.net/image-1.png",
-					Url2x: "https://static-cdn.jtvnw.net/image-2.png",
-					Url4x: "https://static-cdn.jtvnw.net/image-4.png",
+				BackgroundColor: "#c0ffee",
+				Image: models.RewardImage{
+					URL1x: "https://static-cdn.jtvnw.net/image-1.png",
+					URL2x: "https://static-cdn.jtvnw.net/image-2.png",
+					URL4x: "https://static-cdn.jtvnw.net/image-4.png",
 				},
-				DefaultImage:                      models.RewardImage{
-					Url1x: "https://static-cdn.jtvnw.net/default-1.png",
-					Url2x: "https://static-cdn.jtvnw.net/default-2.png",
-					Url4x: "https://static-cdn.jtvnw.net/default-4.png",
+				DefaultImage: models.RewardImage{
+					URL1x: "https://static-cdn.jtvnw.net/default-1.png",
+					URL2x: "https://static-cdn.jtvnw.net/default-2.png",
+					URL4x: "https://static-cdn.jtvnw.net/default-4.png",
 				},
 			},
 		}

--- a/internal/events/reward_event_test.go
+++ b/internal/events/reward_event_test.go
@@ -29,8 +29,8 @@ func TestEventsubReward(t *testing.T) {
 		t.Error("Error unmarshalling JSON")
 	}
 
-	if body.Event.BroadcasterUserId != toUser {
-		t.Errorf("Expected to user %v, got %v", toUser, body.Event.BroadcasterUserId)
+	if body.Event.BroadcasterUserID != toUser {
+		t.Errorf("Expected to user %v, got %v", toUser, body.Event.BroadcasterUserID)
 	}
 
 	if body.Event.Cost != 1337 {

--- a/internal/events/sub_event.go
+++ b/internal/events/sub_event.go
@@ -66,10 +66,12 @@ func GenerateSubBody(params SubscribeParams) (TriggerResponse, error) {
 				CreatedAt: util.GetTimestamp().Format(time.RFC3339),
 			},
 			Event: models.SubEventSubEvent{
-				UserID:              params.FromUser,
-				UserName:            fromUserName,
-				BroadcasterUserID:   params.ToUser,
-				BroadcasterUserName: toUserName,
+				UserID:               params.FromUser,
+				UserLogin:            fromUserName,
+				UserName:             fromUserName,
+				BroadcasterUserID:    params.ToUser,
+				BroadcasterUserLogin: toUserName,
+				BroadcasterUserName:  toUserName,
 			},
 		}
 
@@ -85,7 +87,7 @@ func GenerateSubBody(params SubscribeParams) (TriggerResponse, error) {
 					EventType:      params.Type,
 					EventTimestamp: time.Now().Format(time.RFC3339),
 					Version:        "1.0",
-					EventData: models.SubEventData{
+					EventData: models.SubWebSubEventData{
 						BroadcasterID:   params.ToUser,
 						BroadcasterName: toUserName,
 						UserID:          params.FromUser,

--- a/internal/events/sub_event.go
+++ b/internal/events/sub_event.go
@@ -72,6 +72,8 @@ func GenerateSubBody(params SubscribeParams) (TriggerResponse, error) {
 				BroadcasterUserID:    params.ToUser,
 				BroadcasterUserLogin: toUserName,
 				BroadcasterUserName:  toUserName,
+				Tier:                 "1000",
+				IsGift:               params.IsGift,
 			},
 		}
 

--- a/internal/events/trigger_event.go
+++ b/internal/events/trigger_event.go
@@ -104,7 +104,7 @@ func Fire(p TriggerParameters) (string, error) {
 			Title:     "",
 			Prompt:    "",
 			Status:    p.Status,
-			RewardId:  p.ItemId,
+			RewardID:  p.ItemId,
 			Cost:      p.Cost,
 		})
 

--- a/internal/events/trigger_event.go
+++ b/internal/events/trigger_event.go
@@ -76,6 +76,7 @@ func Fire(p TriggerParameters) (string, error) {
 			FromUser:    p.FromUser,
 			ToUser:      p.ToUser,
 			IsAnonymous: p.IsAnonymous,
+			Bits:        p.Cost,
 		})
 
 	case "follow":

--- a/internal/models/cheer.go
+++ b/internal/models/cheer.go
@@ -3,13 +3,15 @@
 package models
 
 type CheerEventSubEvent struct {
-	UserID              string  `json:"user_id"`
-	UserName            string  `json:"user_name"`
-	BroadcasterUserID   string  `json:"broadcast_user_id"`
-	BroadcasterUserName string  `json:"broadcast_user_name"`
-	IsAnonymous         bool    `json:"is_anonymous"`
-	Message             string  `json:"message"`
-	Bits                float64 `json:"bits"`
+	UserID               string  `json:"user_id"`
+	UserLogin            string  `json:"user_login"`
+	UserName             string  `json:"user_name"`
+	BroadcasterUserID    string  `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string  `json:"broadcaster_user_login"`
+	BroadcasterUserName  string  `json:"broadcaster_user_name"`
+	IsAnonymous          bool    `json:"is_anonymous"`
+	Message              string  `json:"message"`
+	Bits                 float64 `json:"bits"`
 }
 
 type CheerEventSubResponse struct {

--- a/internal/models/cheer.go
+++ b/internal/models/cheer.go
@@ -3,15 +3,15 @@
 package models
 
 type CheerEventSubEvent struct {
-	UserID               string  `json:"user_id"`
-	UserLogin            string  `json:"user_login"`
-	UserName             string  `json:"user_name"`
-	BroadcasterUserID    string  `json:"broadcaster_user_id"`
-	BroadcasterUserLogin string  `json:"broadcaster_user_login"`
-	BroadcasterUserName  string  `json:"broadcaster_user_name"`
-	IsAnonymous          bool    `json:"is_anonymous"`
-	Message              string  `json:"message"`
-	Bits                 float64 `json:"bits"`
+	UserID               string `json:"user_id"`
+	UserLogin            string `json:"user_login"`
+	UserName             string `json:"user_name"`
+	BroadcasterUserID    string `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	BroadcasterUserName  string `json:"broadcaster_user_name"`
+	IsAnonymous          bool   `json:"is_anonymous"`
+	Message              string `json:"message"`
+	Bits                 int64  `json:"bits"`
 }
 
 type CheerEventSubResponse struct {

--- a/internal/models/follow.go
+++ b/internal/models/follow.go
@@ -3,10 +3,12 @@
 package models
 
 type FollowEventSubEvent struct {
-	UserID              string `json:"user_id"`
-	UserName            string `json:"user_name"`
-	BroadcasterUserID   string `json:"broadcaster_user_id"`
-	BroadcasterUserName string `json:"broadcaster_user_name"`
+	UserID               string `json:"user_id"`
+	UserLogin            string `json:"user_login"`
+	UserName             string `json:"user_name"`
+	BroadcasterUserID    string `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	BroadcasterUserName  string `json:"broadcaster_user_name"`
 }
 
 type FollowWebSubResponse struct {

--- a/internal/models/redemption.go
+++ b/internal/models/redemption.go
@@ -3,19 +3,21 @@
 package models
 
 type RedemptionEventSubEvent struct {
-	Id                  string           `json:"id"`
-	BroadcasterUserId   string           `json:"broadcaster_user_id"`
-	BroadcasterUserName string           `json:"broadcaster_user_name"`
-	UserId              string           `json:"user_id"`
-	UserName            string           `json:"user_name"`
-	UserInput           string           `json:"user_input"`
-	Status              string           `json:"status"`
-	Reward              RedemptionReward `json:"reward"`
-	RedeemedAt          string           `json:"redeemed_at"`
+	ID                   string           `json:"id"`
+	BroadcasterUserID    string           `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string           `json:"broadcaster_user_login"`
+	BroadcasterUserName  string           `json:"broadcaster_user_name"`
+	UserID               string           `json:"user_id"`
+	UserLogin            string           `json:"user_login"`
+	UserName             string           `json:"user_name"`
+	UserInput            string           `json:"user_input"`
+	Status               string           `json:"status"`
+	Reward               RedemptionReward `json:"reward"`
+	RedeemedAt           string           `json:"redeemed_at"`
 }
 
 type RedemptionReward struct {
-	Id     string `json:"id"`
+	ID     string `json:"id"`
 	Title  string `json:"title"`
 	Cost   int64  `json:"cost"`
 	Prompt string `json:"prompt"`

--- a/internal/models/reward.go
+++ b/internal/models/reward.go
@@ -3,8 +3,9 @@
 package models
 
 type RewardEventSubEvent struct {
-	Id                                string               `json:"id"`
-	BroadcasterUserId                 string               `json:"broadcaster_user_id"`
+	ID                                string               `json:"id"`
+	BroadcasterUserID                 string               `json:"broadcaster_user_id"`
+	BroadcasterUserLogin              string               `json:"broadcaster_user_login"`
 	BroadcasterUserName               string               `json:"broadcaster_user_name"`
 	IsEnabled                         bool                 `json:"is_enabled"`
 	IsPaused                          bool                 `json:"is_paused"`
@@ -35,9 +36,9 @@ type RewardGlobalCooldown struct {
 }
 
 type RewardImage struct {
-	Url1x string `json:"url_1x"`
-	Url2x string `json:"url_2x"`
-	Url4x string `json:"url_4x"`
+	URL1x string `json:"url_1x"`
+	URL2x string `json:"url_2x"`
+	URL4x string `json:"url_4x"`
 }
 
 type RewardEventSubResponse struct {

--- a/internal/models/subs.go
+++ b/internal/models/subs.go
@@ -38,4 +38,6 @@ type SubEventSubEvent struct {
 	BroadcasterUserID    string `json:"broadcaster_user_id"`
 	BroadcasterUserLogin string `json:"broadcaster_user_login"`
 	BroadcasterUserName  string `json:"broadcaster_user_name"`
+	Tier                 string `json:"tier"`
+	IsGift               bool   `json:"is_gift"`
 }

--- a/internal/models/subs.go
+++ b/internal/models/subs.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package models
 
-type SubEventData struct {
+type SubWebSubEventData struct {
 	BroadcasterID   string `json:"broadcaster_id"`
 	BroadcasterName string `json:"broadcaster_name"`
 	IsGift          bool   `json:"is_gift"`
@@ -19,11 +19,11 @@ type SubWebSubResponse struct {
 }
 
 type SubWebSubResponseData struct {
-	ID             string       `json:"id"`
-	EventType      string       `json:"event_type"`
-	EventTimestamp string       `json:"event_timestamp"`
-	Version        string       `json:"version"`
-	EventData      SubEventData `json:"event_data"`
+	ID             string             `json:"id"`
+	EventType      string             `json:"event_type"`
+	EventTimestamp string             `json:"event_timestamp"`
+	Version        string             `json:"version"`
+	EventData      SubWebSubEventData `json:"event_data"`
 }
 
 type SubEventSubResponse struct {
@@ -32,8 +32,10 @@ type SubEventSubResponse struct {
 }
 
 type SubEventSubEvent struct {
-	UserID              string `json:"user_id"`
-	UserName            string `json:"user_name"`
-	BroadcasterUserID   string `json:"broadcaster_user_id"`
-	BroadcasterUserName string `json:"broadcaster_user_name"`
+	UserID               string `json:"user_id"`
+	UserLogin            string `json:"user_login"`
+	UserName             string `json:"user_name"`
+	BroadcasterUserID    string `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	BroadcasterUserName  string `json:"broadcaster_user_name"`
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Per the announcement in the #eventsub Discord channel, adding login to applicable events and fixing a few small minor issues. 

## Description of Changes: 

- Adds logins to applicable events per the recent update
- Added count support (per PR #8 which added the flag) to Cheer events
- Added the missing `is_gift` and `tier` fields to sub events

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
