### PR TITLE
added ability to export drops entitlements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ twitch-cli
 
 # Test binary, built with `go test -c`
 *.test
+.testing-csv.csv
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The CLI currently supports the following products:
 
 - [api](./docs/api.md)
 - [configure](./docs/configure.md)
+- [drops](./docs/drops.md)
 - [event](docs/event.md)
 - [token](docs/token.md)
 - [version](docs/version.md)

--- a/cmd/drops.go
+++ b/cmd/drops.go
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/twitchdev/twitch-cli/internal/drops"
+)
+
+var (
+	gameID   string
+	userID   string
+	filename string
+)
+
+// dropsCmd represents the drops command
+var dropsCmd = &cobra.Command{
+	Use:   "drops",
+	Short: "Used to interface with Drops services.",
+}
+
+var exportDropsCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Exports a CSV with a list of entitlements from the stored Client ID",
+	Run:   runDropsCmd,
+}
+
+func init() {
+	rootCmd.AddCommand(dropsCmd)
+	dropsCmd.AddCommand(exportDropsCmd)
+
+	exportDropsCmd.Flags().StringVarP(&filename, "filename", "f", "", "Filename to write the output to.")
+	exportDropsCmd.Flags().StringVarP(&gameID, "game-id", "g", "", "ID of the game to get entitlements for.")
+	exportDropsCmd.Flags().StringVarP(&userID, "user-id", "u", "", "ID of the user to get entitlements for.")
+	exportDropsCmd.MarkFlagRequired("filename")
+
+}
+
+func runDropsCmd(cmd *cobra.Command, args []string) {
+	drops.ExportEntitlements(filename, gameID, userID)
+}

--- a/docs/drops.md
+++ b/docs/drops.md
@@ -1,0 +1,32 @@
+# Drops
+- [Drops](#drops)
+  - [Description](#description)
+  - [Export](#export)
+
+## Description 
+
+The `drops` command contains sub-commands to interact with the Drops product. 
+
+## Export
+
+Used to export Drops entitlements into a provided CSV filename. 
+
+**Args**
+
+None.
+
+
+**Flags**
+
+| Flag         | Shorthand | Description                                                                                           | Example                     | Required? (Y/N) |
+|--------------|-----------|-------------------------------------------------------------------------------------------------------|-----------------------------|-----------------|
+| `--filename` | `-f`      | Name of the CSV file to be generated.                                                                 | `-f drops_entitlements.csv` | Y               |
+| `--game-id`  | `-T`      | ID of the game to be filtered for. If unsure, use [api get games](./api.md) described in the example. | `-g websub`                 | N               |
+| `--user-id`  | `-t`      | Denotes the user's TUID of the entitlement to filter for.                                             | `-u 44635596`               | N               |
+
+**Examples**
+
+```sh
+twitch api get games -q "name=Fortnite" 
+twitch drops export -f "fortnite_drops_entitlements.csv" -g 33214
+```

--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,5 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 )

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,7 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -28,7 +28,7 @@ type clientInformation struct {
 
 // NewRequest is used to request data from the Twitch API using a HTTP GET request- this function is a wrapper for the apiRequest function that handles the network call
 func NewRequest(method string, path string, queryParameters []string, body []byte, prettyPrint bool) {
-	client, err := getClientInformation()
+	client, err := GetClientInformation()
 
 	if viper.GetString("BASE_URL") != "" {
 		baseURL = viper.GetString("BASE_URL")
@@ -90,7 +90,7 @@ func ValidOptions(method string) []string {
 	return names
 }
 
-func getClientInformation() (clientInformation, error) {
+func GetClientInformation() (clientInformation, error) {
 	clientID := viper.GetString("clientID")
 	expiration := viper.GetString("tokenexpiration")
 	token := viper.GetString("accessToken")

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -63,18 +63,18 @@ func TestGetClientInformation(t *testing.T) {
 
 	// check in the future
 	viper.Set("tokenexpiration", util.GetTimestamp().Add(10*time.Minute).Format(time.RFC3339Nano))
-	clientInfo, err := getClientInformation()
+	clientInfo, err := GetClientInformation()
 	a.Nil(err)
 	a.Equal(clientInfo.Token, "4567")
 
 	// non-expiring tokens
 	viper.Set("tokenexpiration", "0")
-	clientInfo, err = getClientInformation()
+	clientInfo, err = GetClientInformation()
 	a.Nil(err)
 	a.Equal(clientInfo.Token, "4567")
 
 	// expired, but will fail since it's not valid :)
 	viper.Set("tokenexpiration", "1")
-	clientInfo, err = getClientInformation()
+	clientInfo, err = GetClientInformation()
 	a.NotNil(err)
 }

--- a/internal/drops/client.go
+++ b/internal/drops/client.go
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package drops
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+type RLClient struct {
+	client      *http.Client
+	RateLimiter *rate.Limiter
+}
+
+func (c *RLClient) Do(req *http.Request) (*http.Response, error) {
+	err := c.RateLimiter.Wait(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func NewClient(l *rate.Limiter) *RLClient {
+	client := http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	return &RLClient{
+		client:      &client,
+		RateLimiter: l,
+	}
+}

--- a/internal/drops/client_test.go
+++ b/internal/drops/client_test.go
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package drops
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/twitchdev/twitch-cli/internal/util"
+	"golang.org/x/time/rate"
+)
+
+func TestNewClient(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	var ok = "{\"status\":\"ok\"}"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(ok))
+
+		_, err := ioutil.ReadAll(r.Body)
+		a.Nil(err)
+
+	}))
+
+	rl := rate.NewLimiter(rate.Every(10*time.Second), 50)
+	c := NewClient(rl)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
+	resp, err := c.Do(req)
+	a.Nil(err)
+
+	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	a.Equal(ok, string(body), "Body mismatch")
+
+	req, _ = http.NewRequest(http.MethodGet, "potato", nil)
+	resp, err = c.Do(req)
+	a.NotNil(err)
+}

--- a/internal/drops/exporter.go
+++ b/internal/drops/exporter.go
@@ -1,0 +1,167 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package drops
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/twitchdev/twitch-cli/internal/api"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/request"
+	"github.com/twitchdev/twitch-cli/internal/util"
+	"golang.org/x/time/rate"
+)
+
+type DropsEntitlementExportParameters struct {
+	GameID string
+	UserID string
+	URL    string
+	Cursor string
+}
+
+var (
+	TOKEN        string
+	CLIENT_ID    string
+	ENTITLEMENTS []models.DropsEntitlementsData
+)
+
+var BASE_URL = "https://api.twitch.tv/helix/entitlements/drops"
+
+func ExportEntitlements(filename string, gameID string, userID string) {
+	c, err := api.GetClientInformation()
+	if err != nil {
+		return
+	}
+
+	CLIENT_ID = c.ClientID
+	TOKEN = c.Token
+
+	if viper.GetString("BASE_URL") != "" {
+		BASE_URL = viper.GetString("BASE_URL")
+	}
+
+	p := DropsEntitlementExportParameters{
+		URL:    BASE_URL,
+		GameID: gameID,
+		UserID: userID,
+	}
+	for {
+		var e models.DropsEntitlementsResponse
+		resp, err := makeAPIRequest(p)
+		body, err := ioutil.ReadAll(resp.Body)
+		defer resp.Body.Close()
+		if err != nil {
+			fmt.Printf("Error reading body: %v", err)
+			return
+		}
+		err = json.Unmarshal(body, &e)
+		if err != nil {
+			fmt.Printf("Error reading body: %v", err)
+			return
+		}
+
+		ENTITLEMENTS = append(ENTITLEMENTS, e.Data...)
+
+		if resp.StatusCode == 500 {
+			fmt.Println(fmt.Sprintf("[%v] Got 500 from endpoint; Make sure that your client is marked in the correct organization.", util.GetTimestamp().Format(time.RFC3339)))
+			break
+		}
+
+		if len(e.Data) == 0 {
+			fmt.Println("No results, stopping.")
+			break
+		}
+
+		if e.Pagination.Cursor == "" {
+			fmt.Println(fmt.Sprintf("[%v] End of records, found %v records.", util.GetTimestamp().Format(time.RFC3339), len(ENTITLEMENTS)))
+			break
+		}
+
+		p.Cursor = e.Pagination.Cursor
+
+		fmt.Println(fmt.Sprintf("[%v] Found %v records, hitting next page.", util.GetTimestamp().Format(time.RFC3339), len(e.Data)))
+
+	}
+
+	// don't make a csv if empty :)
+	if len(ENTITLEMENTS) == 0 {
+		return
+	}
+
+	file, err := os.Create(filename)
+	if err != nil {
+		fmt.Printf("Error writing file %v", err)
+		return
+	}
+
+	w := csv.NewWriter(file)
+
+	headers := []string{
+		"id",
+		"user_id",
+		"benefit_id",
+		"timestamp",
+		"game_id",
+	}
+
+	w.Write(headers)
+
+	for _, e := range ENTITLEMENTS {
+		v := make([]string, 0)
+		v = append(v,
+			e.ID,
+			e.UserID,
+			e.BenefitID,
+			e.Timestamp,
+			e.GameID,
+		)
+
+		w.Write(v)
+	}
+	//finish writing
+	w.Flush()
+}
+
+func makeAPIRequest(p DropsEntitlementExportParameters) (*http.Response, error) {
+	u, err := url.Parse(p.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	q.Add("first", "100")
+
+	if p.GameID != "" {
+		q.Add("game_id", p.GameID)
+	}
+	if p.UserID != "" {
+		q.Add("user_id", p.UserID)
+	}
+	if p.Cursor != "" {
+		q.Add("after", p.Cursor)
+	}
+
+	u.RawQuery = q.Encode()
+
+	req, _ := request.NewRequest(http.MethodGet, u.String(), nil)
+	req.Header.Set("Client-ID", CLIENT_ID)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", TOKEN))
+
+	rl := rate.NewLimiter(rate.Every(10*time.Second), 100)
+	client := NewClient(rl)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/internal/drops/exporter_test.go
+++ b/internal/drops/exporter_test.go
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package drops
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
+)
+
+func TestExportEntitlements(t *testing.T) {
+	a := util.SetupTestEnv(t)
+	viper.Set("clientid", "1111")
+	viper.Set("clientsecret", "2222")
+	viper.Set("accesstoken", "4567")
+	viper.Set("refreshtoken", "123")
+	viper.Set("tokenexpiration", "0")
+
+	var okModel = &models.DropsEntitlementsResponse{
+		Data: []models.DropsEntitlementsData{
+			{
+				ID:        "1234",
+				BenefitID: "234",
+				GameID:    "34",
+				UserID:    "4",
+				Timestamp: util.GetTimestamp().Format(time.RFC3339),
+			},
+		},
+		Pagination: struct {
+			Cursor string "json:\"cursor\""
+		}{
+			Cursor: "1234",
+		},
+	}
+	ok, err := json.Marshal(okModel)
+	a.Nil(err)
+
+	var emptyModel = &models.DropsEntitlementsResponse{
+		Data: []models.DropsEntitlementsData{},
+	}
+
+	empty, err := json.Marshal(emptyModel)
+	a.Nil(err)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/data" {
+			w.WriteHeader(http.StatusOK)
+			cursor := r.URL.Query().Get("after")
+			if cursor != "" {
+				w.Write(empty)
+				return
+			}
+			w.Write(ok)
+			_, err := ioutil.ReadAll(r.Body)
+			a.Nil(err)
+		}
+		if r.URL.Path == "/empty" {
+			w.WriteHeader(http.StatusOK)
+			w.Write(empty)
+			_, err := ioutil.ReadAll(r.Body)
+			a.Nil(err)
+		}
+		if r.URL.Path == "/error" {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(ok))
+			_, err := ioutil.ReadAll(r.Body)
+			a.Nil(err)
+		}
+	}))
+	filename := ".testing-csv.csv"
+
+	viper.Set("BASE_URL", ts.URL+"/data")
+	ExportEntitlements(filename, "", "")
+
+	viper.Set("BASE_URL", ts.URL+"/empty")
+	ExportEntitlements(filename, "1", "")
+
+	viper.Set("BASE_URL", ts.URL+"/error")
+	ExportEntitlements(filename, "", "2")
+}

--- a/internal/models/drops.go
+++ b/internal/models/drops.go
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package models
+
+type DropsEntitlementsData struct {
+	ID        string `json:"id"`
+	BenefitID string `json:"benefit_id"`
+	Timestamp string `json:"timestamp"`
+	UserID    string `json:"user_id"`
+	GameID    string `json:"game_id"`
+}
+
+type DropsEntitlementsResponse struct {
+	Pagination struct {
+		Cursor string `json:"cursor"`
+	} `json:"pagination"`
+	Data []DropsEntitlementsData `json:"data"`
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Allows game developers to export Drops entitlements into a CSV for local use/analysis. 

## Description of Changes: 

- Adds a `twitch drops export` function that takes in a filename and (optionally) a game ID/user ID to get a list of entitlements


## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
