### PR TITLE
Better supporting Windows output

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -63,6 +64,14 @@ func NewRequest(method string, path string, queryParameters []string, body []byt
 			fmt.Printf("Error pretty-printing body: %v", err)
 			return
 		}
+
+		// since Command Prompt/Powershell don't support coloring, will pretty print without colors
+		if runtime.GOOS == "windows" {
+			s, _ := json.MarshalIndent(obj, "", "  ")
+			fmt.Println(string(s))
+			return
+		}
+
 		f := colorjson.NewFormatter()
 		f.Indent = 2
 		f.KeyColor = color.New(color.FgBlue).Add(color.Bold)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

This PR fixes a small issue with Windows display of pretty-printing due to linux-style color encodings used in a package. 

## Description of Changes: 

- Pretty-prints on Windows will appear correctly now

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
