### PR TITLE
Properly handling invalid credentials

### DIFF
--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -138,7 +138,7 @@ func CredentialsLogout(p LoginParameters) (LoginResponse, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		log.Printf("API responded with an error while revoking token: %v", resp.Body)
+		log.Printf("API responded with an error while revoking token: %v", string(resp.Body))
 		return LoginResponse{}, errors.New("API responded with an error while revoking token")
 	}
 

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -71,6 +71,11 @@ func ClientCredentialsLogin(p LoginParameters) (LoginResponse, error) {
 		log.Fatal(err.Error())
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("API responded with an error while generating token: %v", string(resp.Body))
+		return LoginResponse{}, errors.New("API responded with an error while revoking token")
+	}
+
 	r, err := handleLoginResponse(resp.Body)
 	if err != nil {
 		log.Printf("Error handling login: %v", err)
@@ -95,6 +100,7 @@ func UserCredentialsLogin(p LoginParameters) (LoginResponse, error) {
 
 	twitchAuthorizeURL += "&state=" + state
 
+	fmt.Println("Opening browser. Press Ctrl+C to cancel...")
 	openBrowser(twitchAuthorizeURL)
 
 	ur, err := userAuthServer()
@@ -147,7 +153,7 @@ func RefreshUserToken(p RefreshParameters) (LoginResponse, error) {
 		return LoginResponse{}, err
 	}
 
-	if resp.StatusCode == http.StatusBadRequest {
+	if resp.StatusCode != http.StatusOK {
 		return LoginResponse{}, errors.New("Error with client while refreshing. Please rerun twitch configure")
 	}
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Per conversation with @BraxtonLanc43, found that the `login.go` functionality wasn't properly checking for errors and could return a blank app access token. 

## Description of Changes: 

- Updated messaging to user if client creds are invalid
- Updated messaging during the browser opening to make clear that Ctrl+C (default binding) cancels the script
- Updated some error messaging to return strings vs. bytes

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
