### PR TITLE
fix typo in update-redemption event

### DIFF
--- a/internal/events/types/channel_points_redemption/redemption_event.go
+++ b/internal/events/types/channel_points_redemption/redemption_event.go
@@ -22,7 +22,7 @@ var triggerSupported = []string{"add-redemption", "update-redemption"}
 var triggerMapping = map[string]map[string]string{
 	models.TransportEventSub: {
 		"add-redemption":    "channel.channel_points_custom_reward_redemption.add",
-		"update-redemption": "tchannel.channel_points_custom_reward_redemption.update",
+		"update-redemption": "channel.channel_points_custom_reward_redemption.update",
 	},
 }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

```sh
twitch event trigger update-redemption
``` 

sends a subscription with type `tchannel.channel_points_custom_reward_redemption.update`

## Description of Changes: 

typo `tchannel.` -> `channel.`

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
