### PR TITLE
Add event triggers for stream.online and stream.offline

### DIFF
--- a/docs/event.md
+++ b/docs/event.md
@@ -30,6 +30,8 @@ Used to either create or send mock events for use with local webhooks testing.
 | `update-redemption` | Channel Points EventSub event for a redemption being updated.                                              |
 | `raid`              | Channel Raid event with a random viewer count.                                                             |
 | `revoke`            | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly. |
+| `streamup`          | Only usable with the `eventsub` transport, a stream online event.                                          |
+| `streamdown`        | Only usable with the `eventsub` transport, a stream offline event.                                         |
 
 **Flags**
 

--- a/docs/event.md
+++ b/docs/event.md
@@ -1,23 +1,23 @@
 # Events
+
 - [Events](#events)
   - [Description](#description)
   - [Trigger](#trigger)
   - [Retrigger](#retrigger)
   - [Verify-Subscription](#verify-subscription)
 
-## Description 
+## Description
 
-The `event` product contains commands to trigger mock events for local webhook testing or migration. 
+The `event` product contains commands to trigger mock events for local webhook testing or migration.
 
 ## Trigger
 
 Used to either create or send mock events for use with local webhooks testing.
 
-
 **Args**
 
 | Argument            | Description                                                                                                |
-|---------------------|------------------------------------------------------------------------------------------------------------|
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
 | `subscribe`         | A standard subscription event. Triggers a basic tier 1 sub.                                                |
 | `unsubscribe`       | A standard unsubscribe event. Triggers a basic tier 1 sub.                                                 |
 | `gift`              | A gifted subscription event. Triggers a basic tier 1 sub.                                                  |
@@ -34,7 +34,7 @@ Used to either create or send mock events for use with local webhooks testing.
 **Flags**
 
 | Flag                | Shorthand | Description                                                                                                                | Example                                   | Required? (Y/N) |
-|---------------------|-----------|----------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|-----------------|
+| ------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | --------------- |
 | `--forward-address` | `-F`      | Web server address for where to send mock events.                                                                          | `-F https://localhost:8080`               | N               |
 | `--transport`       | `-T`      | The method used to send events. Default is eventsub, but can send using websub.                                            | `-T websub`                               | N               |
 | `--to-user`         | `-t`      | Denotes the receiver's TUID of the event, usually the broadcaster.                                                         | `-t 44635596`                             | N               |
@@ -44,7 +44,7 @@ Used to either create or send mock events for use with local webhooks testing.
 | `--count`           | `-c`      | Count of events to fire. This can be used to simulate an influx of subscriptions.                                          | `-c 100`                                  | N               |
 | `--anonymous`       | `-a`      | If the event is anonymous. Only applies to `gift` and `cheer` events.                                                      | `-a`                                      | N               |
 | `--status`          | `-S`      | Status of the event object, currently applies to channel points redemptions.                                               | `-S fulfilled`                            | N               |
-| `--item-id`         | `-i`      | Manually set the ID of the event payload item (for example the reward ID in redemption events).                          | `-i 032e4a6c-4aef-11eb-a9f5-1f703d1f0b92` | N               |
+| `--item-id`         | `-i`      | Manually set the ID of the event payload item (for example the reward ID in redemption events).                            | `-i 032e4a6c-4aef-11eb-a9f5-1f703d1f0b92` | N               |
 | `--cost`            | `-C`      | Amount of bits or channel points redeemed/used in the event.                                                               | `-C 250`                                  | N               |
 
 **Examples**
@@ -56,9 +56,9 @@ twitch event trigger cheer -f 1234 -t 4567 // generates JSON for a cheer event f
 
 ## Retrigger
 
-Allows previous events to be refired based on the event ID. The ID is noted within the event itself, such as in the "subscription" payload of standard webhooks. 
+Allows previous events to be refired based on the event ID. The ID is noted within the event itself, such as in the "subscription" payload of standard webhooks.
 
-For example, for: 
+For example, for:
 
 ```json
 {
@@ -69,19 +69,19 @@ For example, for:
   }
 }
 ```
-The resulting ID would be `713f3254-0178-9757-7439-d779400c0999`. 
+
+The resulting ID would be `713f3254-0178-9757-7439-d779400c0999`.
 
 **Args**
 None
 
 **Flags**
 
-| Flag                | Shorthand | Description                                                                                                                | Example                     | Required? (Y/N) |
-|---------------------|-----------|----------------------------------------------------------------------------------------------------------------------------|-----------------------------|-----------------|
-| `--forward-address` | `-F`      | Web server address for where to send mock events.                                                                          | `-F https://localhost:8080` | N               |
-| `--id`              | `-i`      | The ID of the event to refire.                                                                                             | `-i <id>`                   | Y               |
-| `--secret`          | `-s`      | Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC.                                               | `-s testsecret`             | N               |
-
+| Flag                | Shorthand | Description                                                                  | Example                     | Required? (Y/N) |
+| ------------------- | --------- | ---------------------------------------------------------------------------- | --------------------------- | --------------- |
+| `--forward-address` | `-F`      | Web server address for where to send mock events.                            | `-F https://localhost:8080` | N               |
+| `--id`              | `-i`      | The ID of the event to refire.                                               | `-i <id>`                   | Y               |
+| `--secret`          | `-s`      | Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC. | `-s testsecret`             | N               |
 
 **Examples**
 
@@ -91,12 +91,12 @@ twitch event retrigger -i "713f3254-0178-9757-7439-d779400c0999" -F https://loca
 
 ## Verify-Subscription
 
-Allows you to test if your webserver responds to subscription requests properly. 
+Allows you to test if your webserver responds to subscription requests properly.
 
 **Args**
 
 | Argument            | Description                                                                                                |
-|---------------------|------------------------------------------------------------------------------------------------------------|
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
 | `subscribe`         | A standard subscription event. Triggers a basic tier 1 sub.                                                |
 | `unsubscribe`       | A standard unsubscribe event. Triggers a basic tier 1 sub.                                                 |
 | `gift`              | A gifted subscription event. Triggers a basic tier 1 sub.                                                  |
@@ -109,14 +109,16 @@ Allows you to test if your webserver responds to subscription requests properly.
 | `update-redemption` | Channel Points EventSub event for a redemption being updated.                                              |
 | `raid`              | Channel Raid event with a random viewer count.                                                             |
 | `revoke`            | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly. |
+| `streamup`          | Only usable with the `eventsub` transport, a stream online event.                                          |
+| `streamdown`        | Only usable with the `eventsub` transport, a stream offline event.                                         |
 
 **Flags**
 
-| Flag                | Shorthand | Description                                                                                                                | Example                     | Required? (Y/N) |
-|---------------------|-----------|----------------------------------------------------------------------------------------------------------------------------|-----------------------------|-----------------|
-| `--forward-address` | `-F`      | Web server address for where to send mock subscription.                                                                    | `-F https://localhost:8080` | Y               |
-| `--secret`          | `-s`      | Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC.                                               | `-s testsecret`             | N               |
-| `--transport`       | `-T`      | The method used to send events. Default is eventsub, but can send using websub.                                            | `-T websub`                 | N               |
+| Flag                | Shorthand | Description                                                                     | Example                     | Required? (Y/N) |
+| ------------------- | --------- | ------------------------------------------------------------------------------- | --------------------------- | --------------- |
+| `--forward-address` | `-F`      | Web server address for where to send mock subscription.                         | `-F https://localhost:8080` | Y               |
+| `--secret`          | `-s`      | Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC.    | `-s testsecret`             | N               |
+| `--transport`       | `-T`      | The method used to send events. Default is eventsub, but can send using websub. | `-T websub`                 | N               |
 
 **Examples**
 

--- a/internal/events/types/streamdown/streamdown.go
+++ b/internal/events/types/streamdown/streamdown.go
@@ -52,16 +52,10 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 			},
 			Event: models.StreamDownEventSubEvent{
 				BroadcasterUserID:    params.ToUserID,
-				BroadcasterUserLogin: params.ToUserID,
+				BroadcasterUserLogin: params.ToUserName,
 				BroadcasterUserName:  params.ToUserName,
 			},
 		}
-		event, err = json.Marshal(body)
-		if err != nil {
-			return events.MockEventResponse{}, err
-		}
-	case models.TransportWebSub:
-		body := models.FollowWebSubResponse{} // replace with actual model in internal/models
 		event, err = json.Marshal(body)
 		if err != nil {
 			return events.MockEventResponse{}, err

--- a/internal/events/types/streamdown/streamdown.go
+++ b/internal/events/types/streamdown/streamdown.go
@@ -1,0 +1,95 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package streamdown
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
+)
+
+var transportsSupported = map[string]bool{
+	models.TransportWebSub:   false,
+	models.TransportEventSub: true,
+}
+
+var triggerSupported = []string{"streamdown"}
+
+var triggerMapping = map[string]map[string]string{
+	models.TransportWebSub: {
+		"streamdown": "channel.update",
+	},
+	models.TransportEventSub: {
+		"streamdown": "stream.offline",
+	},
+}
+
+type Event struct{}
+
+func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEventResponse, error) {
+	var event []byte
+	var err error
+
+	switch params.Transport {
+	case models.TransportEventSub:
+		body := &models.EventsubResponse{
+			Subscription: models.EventsubSubscription{
+				ID:      params.ID,
+				Status:  "enabled",
+				Type:    triggerMapping[params.Transport][params.Trigger],
+				Version: "1",
+				Condition: models.EventsubCondition{
+					BroadcasterUserID: params.ToUserID,
+				},
+				Transport: models.EventsubTransport{
+					Method:   "webhook",
+					Callback: "null",
+				},
+				CreatedAt: util.GetTimestamp().Format(time.RFC3339Nano),
+			},
+			Event: models.StreamDownEventSubEvent{
+				BroadcasterUserID:    params.ToUserID,
+				BroadcasterUserLogin: params.ToUserID,
+				BroadcasterUserName:  params.ToUserName,
+			},
+		}
+		event, err = json.Marshal(body)
+		if err != nil {
+			return events.MockEventResponse{}, err
+		}
+	case models.TransportWebSub:
+		body := models.FollowWebSubResponse{} // replace with actual model in internal/models
+		event, err = json.Marshal(body)
+		if err != nil {
+			return events.MockEventResponse{}, err
+		}
+	default:
+		return events.MockEventResponse{}, nil
+	}
+
+	return events.MockEventResponse{
+		ID:       params.ID,
+		JSON:     event,
+		FromUser: params.FromUserID,
+		ToUser:   params.ToUserID,
+	}, nil
+}
+
+func (e Event) ValidTransport(t string) bool {
+	return transportsSupported[t]
+}
+
+func (e Event) ValidTrigger(t string) bool {
+	for _, ts := range triggerSupported {
+		if ts == t {
+			return true
+		}
+	}
+	return false
+}
+func (e Event) GetTopic(transport string, trigger string) string {
+	return triggerMapping[transport][trigger]
+}

--- a/internal/events/types/streamdown/streamdown_test.go
+++ b/internal/events/types/streamdown/streamdown_test.go
@@ -34,25 +34,6 @@ func TestEventSub(t *testing.T) {
 	// write actual tests here (making sure you set appropriate values and the like) for eventsub
 }
 
-func TestWebSub(t *testing.T) {
-	a := util.SetupTestEnv(t)
-
-	params := *&events.MockEventParameters{
-		FromUserID: fromUser,
-		ToUserID:   toUser,
-		Transport:  models.TransportWebSub,
-		Trigger:    "unsubscribe",
-	}
-
-	r, err := Event{}.GenerateEvent(params)
-	a.Nil(err)
-
-	var body models.SubWebSubResponse // replace with actual value
-	err = json.Unmarshal(r.JSON, &body)
-	a.Nil(err)
-
-	// write tests here for websub
-}
 func TestFakeTransport(t *testing.T) {
 	a := util.SetupTestEnv(t)
 

--- a/internal/events/types/streamdown/streamdown_test.go
+++ b/internal/events/types/streamdown/streamdown_test.go
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package streamdown
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
+)
+
+var fromUser = "1234"
+var toUser = "4567"
+
+func TestEventSub(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportEventSub,
+		Trigger:    "streamdown",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.StreamDownEventSubResponse
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	// write actual tests here (making sure you set appropriate values and the like) for eventsub
+}
+
+func TestWebSub(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportWebSub,
+		Trigger:    "unsubscribe",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.SubWebSubResponse // replace with actual value
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	// write tests here for websub
+}
+func TestFakeTransport(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  "fake_transport",
+		Trigger:    "unsubscribe",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+	a.Empty(r)
+}
+func TestValidTrigger(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	r := Event{}.ValidTrigger("streamdown")
+	a.Equal(true, r)
+
+	r = Event{}.ValidTrigger("notgift")
+	a.Equal(false, r)
+}
+
+func TestValidTransport(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	r := Event{}.ValidTransport(models.TransportEventSub)
+	a.Equal(true, r)
+
+	r = Event{}.ValidTransport("noteventsub")
+	a.Equal(false, r)
+}
+func TestGetTopic(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	r := Event{}.GetTopic(models.TransportEventSub, "streamdown")
+	a.NotNil(r)
+}

--- a/internal/events/types/streamup/streamup.go
+++ b/internal/events/types/streamup/streamup.go
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package streamup
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
+)
+
+var transportsSupported = map[string]bool{
+	models.TransportWebSub:   false,
+	models.TransportEventSub: true,
+}
+
+var triggerSupported = []string{"streamup"}
+
+var triggerMapping = map[string]map[string]string{
+	models.TransportWebSub: {
+		"streamup": "channel.update",
+	},
+	models.TransportEventSub: {
+		"streamup": "stream.online",
+	},
+}
+
+type Event struct{}
+
+func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEventResponse, error) {
+	var event []byte
+	var err error
+
+	switch params.Transport {
+	case models.TransportEventSub:
+		body := &models.EventsubResponse{
+			Subscription: models.EventsubSubscription{
+				ID:      params.ID,
+				Status:  "enabled",
+				Type:    triggerMapping[params.Transport][params.Trigger],
+				Version: "1",
+				Condition: models.EventsubCondition{
+					BroadcasterUserID: params.ToUserID,
+				},
+				Transport: models.EventsubTransport{
+					Method:   "webhook",
+					Callback: "null",
+				},
+				CreatedAt: util.GetTimestamp().Format(time.RFC3339Nano),
+			},
+			Event: models.StreamUpEventSubEvent{
+				ID:                   util.RandomUserID(),
+				BroadcasterUserID:    params.ToUserID,
+				BroadcasterUserLogin: params.ToUserID,
+				BroadcasterUserName:  params.ToUserName,
+				Type:                 "live",
+				StartedAt:            util.GetTimestamp().Format(time.RFC3339Nano),
+			},
+		}
+		event, err = json.Marshal(body)
+		if err != nil {
+			return events.MockEventResponse{}, err
+		}
+	case models.TransportWebSub:
+		body := models.FollowWebSubResponse{} // replace with actual model in internal/models
+		event, err = json.Marshal(body)
+		if err != nil {
+			return events.MockEventResponse{}, err
+		}
+	default:
+		return events.MockEventResponse{}, nil
+	}
+
+	return events.MockEventResponse{
+		ID:       params.ID,
+		JSON:     event,
+		FromUser: params.FromUserID,
+		ToUser:   params.ToUserID,
+	}, nil
+}
+
+func (e Event) ValidTransport(t string) bool {
+	return transportsSupported[t]
+}
+
+func (e Event) ValidTrigger(t string) bool {
+	for _, ts := range triggerSupported {
+		if ts == t {
+			return true
+		}
+	}
+	return false
+}
+func (e Event) GetTopic(transport string, trigger string) string {
+	return triggerMapping[transport][trigger]
+}

--- a/internal/events/types/streamup/streamup.go
+++ b/internal/events/types/streamup/streamup.go
@@ -53,18 +53,12 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 			Event: models.StreamUpEventSubEvent{
 				ID:                   util.RandomUserID(),
 				BroadcasterUserID:    params.ToUserID,
-				BroadcasterUserLogin: params.ToUserID,
+				BroadcasterUserLogin: params.ToUserName,
 				BroadcasterUserName:  params.ToUserName,
 				Type:                 "live",
 				StartedAt:            util.GetTimestamp().Format(time.RFC3339Nano),
 			},
 		}
-		event, err = json.Marshal(body)
-		if err != nil {
-			return events.MockEventResponse{}, err
-		}
-	case models.TransportWebSub:
-		body := models.FollowWebSubResponse{} // replace with actual model in internal/models
 		event, err = json.Marshal(body)
 		if err != nil {
 			return events.MockEventResponse{}, err

--- a/internal/events/types/streamup/streamup_test.go
+++ b/internal/events/types/streamup/streamup_test.go
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package streamup
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
+)
+
+var fromUser = "1234"
+var toUser = "4567"
+
+func TestEventSub(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportEventSub,
+		Trigger:    "streamup",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.StreamUpEventSubResponse
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	// write actual tests here (making sure you set appropriate values and the like) for eventsub
+}
+
+func TestWebSub(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportWebSub,
+		Trigger:    "unsubscribe",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.SubWebSubResponse // replace with actual value
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	// write tests here for websub
+}
+func TestFakeTransport(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  "fake_transport",
+		Trigger:    "unsubscribe",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+	a.Empty(r)
+}
+func TestValidTrigger(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	r := Event{}.ValidTrigger("streamup")
+	a.Equal(true, r)
+
+	r = Event{}.ValidTrigger("notgift")
+	a.Equal(false, r)
+}
+
+func TestValidTransport(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	r := Event{}.ValidTransport(models.TransportEventSub)
+	a.Equal(true, r)
+
+	r = Event{}.ValidTransport("noteventsub")
+	a.Equal(false, r)
+}
+func TestGetTopic(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	r := Event{}.GetTopic(models.TransportEventSub, "streamup")
+	a.NotNil(r)
+}

--- a/internal/events/types/streamup/streamup_test.go
+++ b/internal/events/types/streamup/streamup_test.go
@@ -34,25 +34,6 @@ func TestEventSub(t *testing.T) {
 	// write actual tests here (making sure you set appropriate values and the like) for eventsub
 }
 
-func TestWebSub(t *testing.T) {
-	a := util.SetupTestEnv(t)
-
-	params := *&events.MockEventParameters{
-		FromUserID: fromUser,
-		ToUserID:   toUser,
-		Transport:  models.TransportWebSub,
-		Trigger:    "unsubscribe",
-	}
-
-	r, err := Event{}.GenerateEvent(params)
-	a.Nil(err)
-
-	var body models.SubWebSubResponse // replace with actual value
-	err = json.Unmarshal(r.JSON, &body)
-	a.Nil(err)
-
-	// write tests here for websub
-}
 func TestFakeTransport(t *testing.T) {
 	a := util.SetupTestEnv(t)
 

--- a/internal/events/types/types.go
+++ b/internal/events/types/types.go
@@ -13,6 +13,8 @@ import (
 	"github.com/twitchdev/twitch-cli/internal/events/types/extension_transaction"
 	"github.com/twitchdev/twitch-cli/internal/events/types/follow"
 	"github.com/twitchdev/twitch-cli/internal/events/types/raid"
+	"github.com/twitchdev/twitch-cli/internal/events/types/streamdown"
+	"github.com/twitchdev/twitch-cli/internal/events/types/streamup"
 	"github.com/twitchdev/twitch-cli/internal/events/types/subscribe"
 )
 
@@ -26,6 +28,8 @@ func All() []events.MockEvent {
 		follow.Event{},
 		raid.Event{},
 		subscribe.Event{},
+		streamup.Event{},
+		streamdown.Event{},
 	}
 }
 

--- a/internal/models/streamdown.go
+++ b/internal/models/streamdown.go
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package models
+
+type StreamDownEventSubResponse struct {
+	Subscription EventsubSubscription  `json:"subscription"`
+	Event        StreamUpEventSubEvent `json:"event"`
+}
+
+type StreamDownEventSubEvent struct {
+	BroadcasterUserID    string `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	BroadcasterUserName  string `json:"broadcaster_user_name"`
+}

--- a/internal/models/streamup.go
+++ b/internal/models/streamup.go
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package models
+
+type StreamUpEventSubResponse struct {
+	Subscription EventsubSubscription  `json:"subscription"`
+	Event        StreamUpEventSubEvent `json:"event"`
+}
+
+type StreamUpEventSubEvent struct {
+	ID                   string `json:"id"`
+	BroadcasterUserID    string `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	BroadcasterUserName  string `json:"broadcaster_user_name"`
+	Type                 string `json:"type"`
+	StartedAt            string `json:"started_at"`
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Adds even triggers for stream.online and stream.offline EventSub events. Resolves #19.

## Description of Changes: 

- Added `twitch event trigger streamup` that maps to the `stream.online` event
- Added `twitch event trigger streamdown` that maps to the `stream.offline` event

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
