### PR TITLE
Adding ID to channel points event per #37

### DIFF
--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -60,6 +60,7 @@ func Fire(p TriggerParameters) (string, error) {
 		IsAnonymous:  p.IsAnonymous,
 		Cost:         p.Cost,
 		Status:       p.Status,
+		ItemID:       p.ItemID,
 	}
 
 	e, err := types.GetByTriggerAndTransport(p.Event, p.Transport)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Fixes #37.

## Description of Changes: 

- ID wasn't being passed down to the channel points object, so it was generating a fresh ID each time- this fixes that. 

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
