### PR TITLE
fixing login going forward

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -138,7 +138,6 @@ func GetClientInformation() (clientInformation, error) {
 		if err != nil {
 			return clientInformation{}, err
 		}
-		fmt.Printf("%v", r)
 		token = r.Response.AccessToken
 	}
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

This fixes an issue found by SudoForkBomb on Discord where OSX wouldn't work with multiple scopes. As a result, migrated the login to properly handle nonstandard query parameters; should be more stable long term and addresses the found bug. 

## Description of Changes: 

- Changed `login.go` to properly use the URL lib in Golang, along with using the query parameter feature
- Fixes bug in OSX not accepting multiple scopes

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
