### PR TITLE
Moderator change events on WebSub

### DIFF
--- a/docs/event.md
+++ b/docs/event.md
@@ -32,8 +32,8 @@ Used to either create or send mock events for use with local webhooks testing.
 | `revoke`            | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly. |
 | `streamup`          | Only usable with the `eventsub` transport, a stream online event.                                          |
 | `streamdown`        | Only usable with the `eventsub` transport, a stream offline event.                                         |
-| `add-moderator`     | Broadcaster add a moderator to their channel.                                                              |
-| `remove-moderator`  | Broadcaster removes a moderator from their channel.                                                        |
+| `add-moderator`     | Channel moderator add event.                                                                               |
+| `remove-moderator`  | Channel moderator removal event.                                                                           |
 
 **Flags**
 
@@ -115,8 +115,8 @@ Allows you to test if your webserver responds to subscription requests properly.
 | `revoke`            | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly. |
 | `streamup`          | Only usable with the `eventsub` transport, a stream online event.                                          |
 | `streamdown`        | Only usable with the `eventsub` transport, a stream offline event.                                         |
-| `add-moderator`     | Broadcaster add a moderator to their channel.                                                              |
-| `remove-moderator`  | Broadcaster removes a moderator from their channel.                                                        |
+| `add-moderator`     | Channel moderator add event.                                                                               |
+| `remove-moderator`  | Channel moderator removal event.                                                                           |
 
 **Flags**
 

--- a/docs/event.md
+++ b/docs/event.md
@@ -32,6 +32,8 @@ Used to either create or send mock events for use with local webhooks testing.
 | `revoke`            | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly. |
 | `streamup`          | Only usable with the `eventsub` transport, a stream online event.                                          |
 | `streamdown`        | Only usable with the `eventsub` transport, a stream offline event.                                         |
+| `add-moderator`     | Broadcaster add a moderator to their channel.                                                              |
+| `remove-moderator`  | Broadcaster removes a moderator from their channel.                                                        |
 
 **Flags**
 
@@ -113,6 +115,8 @@ Allows you to test if your webserver responds to subscription requests properly.
 | `revoke`            | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly. |
 | `streamup`          | Only usable with the `eventsub` transport, a stream online event.                                          |
 | `streamdown`        | Only usable with the `eventsub` transport, a stream offline event.                                         |
+| `add-moderator`     | Broadcaster add a moderator to their channel.                                                              |
+| `remove-moderator`  | Broadcaster removes a moderator from their channel.                                                        |
 
 **Flags**
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.14
 
 require (
 	github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2
-	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.10.0
 	github.com/hokaccha/go-prettyjson v0.0.0-20201222001619-a42f9ac2ec8e // indirect
 	github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2
+	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.10.0
 	github.com/hokaccha/go-prettyjson v0.0.0-20201222001619-a42f9ac2ec8e // indirect
 	github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7 // indirect

--- a/internal/events/models.go
+++ b/internal/events/models.go
@@ -14,6 +14,8 @@ var triggerSupported = map[string]bool{
 	"add-reward":        true,
 	"update-reward":     true,
 	"remove-reward":     true,
+	"add-moderator":     true,
+	"remove-moderator":  true,
 }
 
 var transportSupported = map[string]bool{

--- a/internal/events/types/moderator_change/moderator_change_event.go
+++ b/internal/events/types/moderator_change/moderator_change_event.go
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package moderator_change
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
+)
+
+var transportsSupported = map[string]bool{
+	models.TransportWebSub:   true,
+	models.TransportEventSub: false,
+}
+
+var triggerSupported = []string{"add-moderator", "remove-moderator"}
+
+var triggerMapping = map[string]map[string]string{
+	models.TransportWebSub: {
+		"add-moderator":    "moderation.moderator.add",
+		"remove-moderator": "moderation.moderator.remove",
+	},
+}
+
+type Event struct{}
+
+func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEventResponse, error) {
+	var event []byte
+	var err error
+
+	switch params.Transport {
+	case models.TransportEventSub:
+		return events.MockEventResponse{}, errors.New("Moderator change events are currently in beta on EventSub")
+	case models.TransportWebSub:
+		body := *&models.ModeratorChangeWebSubResponse{
+			Data: []models.ModeratorChangeWebSubEvent{
+				{
+					ID:             params.ID,
+					EventType:      triggerMapping[params.Transport][params.Trigger],
+					EventTimestamp: util.GetTimestamp().Format(time.RFC3339),
+					Version:        "v1",
+					EventData: models.ModeratorChangeEventData{
+						BroadcasterID:   params.ToUserID,
+						BroadcasterName: params.ToUserName,
+						UserID:          params.FromUserID,
+						UserName:        params.FromUserName,
+					},
+				},
+			},
+		}
+		event, err = json.Marshal(body)
+		if err != nil {
+			return events.MockEventResponse{}, err
+		}
+
+	default:
+		return events.MockEventResponse{}, nil
+	}
+
+	return events.MockEventResponse{
+		ID:       params.ID,
+		JSON:     event,
+		FromUser: params.FromUserID,
+		ToUser:   params.ToUserID,
+	}, nil
+}
+
+func (e Event) ValidTransport(t string) bool {
+	return transportsSupported[t]
+}
+
+func (e Event) ValidTrigger(t string) bool {
+	for _, ts := range triggerSupported {
+		if ts == t {
+			return true
+		}
+	}
+	return false
+}
+func (e Event) GetTopic(transport string, trigger string) string {
+	return triggerMapping[transport][trigger]
+}

--- a/internal/events/types/moderator_change/moderator_change_event_test.go
+++ b/internal/events/types/moderator_change/moderator_change_event_test.go
@@ -1,0 +1,89 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package moderator_change
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
+)
+
+var fromUser = "1234"
+var toUser = "4567"
+
+func TestWebSub(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportWebSub,
+		Trigger:    "add-moderator",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.ModeratorChangeWebSubResponse
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	a.Equal("moderation.moderator.add", body.Data[0].EventType, "Expected event type %v, got %v", "moderation.moderator.add", body.Data[0].EventType)
+	a.Equal(toUser, body.Data[0].EventData.BroadcasterID, "Expected to user %v, got %v", toUser, body.Data[0].EventData.BroadcasterID)
+	a.Equal(fromUser, body.Data[0].EventData.UserID, "Expected from user %v, got %v", fromUser, body.Data[0].EventData.UserID)
+
+	params = *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportWebSub,
+	}
+}
+func TestFakeTransport(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  "fake_transport",
+		Trigger:    "add-moderator",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+	a.Empty(r)
+}
+func TestValidTrigger(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	r := Event{}.ValidTrigger("add-moderator")
+	a.Equal(true, r)
+
+	r = Event{}.ValidTrigger("remove-moderator")
+	a.Equal(true, r)
+
+	r = Event{}.ValidTrigger("update-moderator")
+	a.Equal(false, r)
+}
+
+func TestValidTransport(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	r := Event{}.ValidTransport(models.TransportWebSub)
+	a.Equal(true, r)
+
+	r = Event{}.ValidTransport(models.TransportEventSub)
+	a.Equal(false, r)
+}
+
+func TestGetTopic(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	r := Event{}.GetTopic(models.TransportWebSub, "add-moderator")
+	a.Equal("moderation.moderator.add", r, "Expected %v, got %v", "moderation.moderator.add", r)
+
+	r = Event{}.GetTopic(models.TransportWebSub, "remove-moderator")
+	a.Equal("moderation.moderator.remove", r, "Expected %v, got %v", "moderation.moderator.remove", r)
+}

--- a/internal/events/types/types.go
+++ b/internal/events/types/types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/twitchdev/twitch-cli/internal/events/types/cheer"
 	"github.com/twitchdev/twitch-cli/internal/events/types/extension_transaction"
 	"github.com/twitchdev/twitch-cli/internal/events/types/follow"
+	"github.com/twitchdev/twitch-cli/internal/events/types/moderator_change"
 	"github.com/twitchdev/twitch-cli/internal/events/types/raid"
 	"github.com/twitchdev/twitch-cli/internal/events/types/streamdown"
 	"github.com/twitchdev/twitch-cli/internal/events/types/streamup"
@@ -30,6 +31,7 @@ func All() []events.MockEvent {
 		subscribe.Event{},
 		streamup.Event{},
 		streamdown.Event{},
+		moderator_change.Event{},
 	}
 }
 

--- a/internal/models/moderator_change.go
+++ b/internal/models/moderator_change.go
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package models
+
+type ModeratorChangeWebSubEvent struct {
+	ID             string                   `json:"id"`
+	EventType      string                   `json:"event_type"`
+	EventTimestamp string                   `json:"event_timestamp"`
+	Version        string                   `json:"version"`
+	EventData      ModeratorChangeEventData `json:"event_data"`
+}
+
+type ModeratorChangeEventData struct {
+	BroadcasterID   string `json:"broadcaster_id"`
+	BroadcasterName string `json:"broadcaster_name"`
+	UserID          string `json:"user_id"`
+	UserName        string `json:"user_name"`
+}
+
+type ModeratorChangeWebSubResponse struct {
+	Data []ModeratorChangeWebSubEvent `json:"data"`
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Adds WebSub [Moderator Change](https://dev.twitch.tv/docs/api/webhooks-reference#topic-moderator-change-events) events. 

## Description of Changes: 

- `twitch event trigger add-moderator -T websub` that maps to the `moderation.moderator.add` event
- `twitch event trigger remove-moderator -T websub` that maps to the `moderation.moderator.remove` event

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
