### PR TITLE
Moderator change events on EventSub

### DIFF
--- a/internal/events/types/moderator_change/moderator_change_event_test.go
+++ b/internal/events/types/moderator_change/moderator_change_event_test.go
@@ -14,6 +14,28 @@ import (
 var fromUser = "1234"
 var toUser = "4567"
 
+func TestEventSub(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportEventSub,
+		Trigger:    "add-moderator",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.ModeratorChangeEventSubResponse
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	a.Equal("channel.moderator.add", body.Subscription.Type, "Expected event type %v, got %v", "channel.moderator.add", body.Subscription.Type)
+	a.Equal(toUser, body.Event.BroadcasterUserID, "Expected to user %v, got %v", toUser, body.Event.BroadcasterUserID)
+	a.Equal(fromUser, body.Event.UserID, "Expected from user %v, got %v", r.ToUser, body.Event.UserID)
+}
+
 func TestWebSub(t *testing.T) {
 	a := util.SetupTestEnv(t)
 
@@ -75,7 +97,7 @@ func TestValidTransport(t *testing.T) {
 	a.Equal(true, r)
 
 	r = Event{}.ValidTransport(models.TransportEventSub)
-	a.Equal(false, r)
+	a.Equal(true, r)
 }
 
 func TestGetTopic(t *testing.T) {

--- a/internal/models/moderator_change.go
+++ b/internal/models/moderator_change.go
@@ -20,3 +20,17 @@ type ModeratorChangeEventData struct {
 type ModeratorChangeWebSubResponse struct {
 	Data []ModeratorChangeWebSubEvent `json:"data"`
 }
+
+type ModeratorChangeEventSubResponse struct {
+	Subscription EventsubSubscription         `json:"subscription"`
+	Event        ModeratorChangeEventSubEvent `json:"event"`
+}
+
+type ModeratorChangeEventSubEvent struct {
+	UserID               string `json:"user_id"`
+	UserLogin            string `json:"user_login"`
+	UserName             string `json:"user_name"`
+	BroadcasterUserID    string `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	BroadcasterUserName  string `json:"broadcaster_user_name"`
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Adds EventSub Moderator [Add](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelmoderatoradd-beta) and [Remove](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelmoderatorremove-beta) events. 

## Description of Changes: 

- `twitch event trigger add-moderator` that maps to the `channel.moderator.add` event
- `twitch event trigger remove-moderator` that maps to the `channel.moderator.remove` event

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
