### PR TITLE
stream_change support addition

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -26,6 +26,7 @@ var (
 	itemID         string
 	cost           int64
 	count          int
+	streamTitle	   string
 )
 
 var eventCmd = &cobra.Command{
@@ -83,6 +84,7 @@ func init() {
 	triggerCmd.Flags().StringVarP(&status, "status", "S", "", "Status of the event object, currently applies to channel points redemptions.")
 	triggerCmd.Flags().StringVarP(&itemID, "item-id", "i", "", "Manually set the ID of the event payload item (for example the reward ID in redemption events).")
 	triggerCmd.Flags().Int64VarP(&cost, "cost", "C", 0, "Amount of bits or channel points redeemed/used in the event.")
+	triggerCmd.Flags().StringVarP(&streamTitle, "description", "d", "", "Title the stream should be updated with.")
 
 	// retrigger flags
 	retriggerCmd.Flags().StringVarP(&forwardAddress, "forward-address", "F", "", "Forward address for mock event.")
@@ -125,6 +127,7 @@ func triggerCmdRun(cmd *cobra.Command, args []string) {
 			Status:         status,
 			ItemID:         itemID,
 			Cost:           cost,
+			StreamTitle:	streamTitle,
 		})
 
 		if err != nil {

--- a/docs/event.md
+++ b/docs/event.md
@@ -30,7 +30,7 @@ Used to either create or send mock events for use with local webhooks testing.
 | `update-redemption` | Channel Points EventSub event for a redemption being updated.                                              |
 | `raid`              | Channel Raid event with a random viewer count.                                                             |
 | `revoke`            | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly. |
-| `stream_change`     | Stream Changed event.                                                                                      |
+| `stream-change`     | Stream Changed event.                                                                                      |
 | `streamup`          | Only usable with the `eventsub` transport, a stream online event.                                          |
 | `streamdown`        | Only usable with the `eventsub` transport, a stream offline event.                                         |
 | `add-moderator`     | Channel moderator add event.                                                                               |

--- a/docs/event.md
+++ b/docs/event.md
@@ -30,6 +30,7 @@ Used to either create or send mock events for use with local webhooks testing.
 | `update-redemption` | Channel Points EventSub event for a redemption being updated.                                              |
 | `raid`              | Channel Raid event with a random viewer count.                                                             |
 | `revoke`            | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly. |
+| `stream_change`     | Stream Changed event.                                                                                      |
 | `streamup`          | Only usable with the `eventsub` transport, a stream online event.                                          |
 | `streamdown`        | Only usable with the `eventsub` transport, a stream offline event.                                         |
 | `add-moderator`     | Channel moderator add event.                                                                               |
@@ -50,6 +51,7 @@ Used to either create or send mock events for use with local webhooks testing.
 | `--status`          | `-S`      | Status of the event object, currently applies to channel points redemptions.                                               | `-S fulfilled`                            | N               |
 | `--item-id`         | `-i`      | Manually set the ID of the event payload item (for example the reward ID in redemption events).                            | `-i 032e4a6c-4aef-11eb-a9f5-1f703d1f0b92` | N               |
 | `--cost`            | `-C`      | Amount of bits or channel points redeemed/used in the event.                                                               | `-C 250`                                  | N               |
+| `--description`            | `-d`      | Title the stream should be updated with.                                                                            | `-d Awesome new title!`                                  | N               |
 
 **Examples**
 
@@ -113,6 +115,7 @@ Allows you to test if your webserver responds to subscription requests properly.
 | `update-redemption` | Channel Points EventSub event for a redemption being updated.                                              |
 | `raid`              | Channel Raid event with a random viewer count.                                                             |
 | `revoke`            | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly. |
+| `stream_change`     | Stream changed event.                                                                                      |
 | `streamup`          | Only usable with the `eventsub` transport, a stream online event.                                          |
 | `streamdown`        | Only usable with the `eventsub` transport, a stream offline event.                                         |
 | `add-moderator`     | Channel moderator add event.                                                                               |

--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -17,6 +17,7 @@ type MockEventParameters struct {
 	Status       string
 	ItemID       string
 	Cost         int64
+	StreamTitle  string
 }
 
 type MockEventResponse struct {

--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -26,6 +26,7 @@ type TriggerParameters struct {
 	Secret         string
 	Verbose        bool
 	Count          int
+	StreamTitle	   string
 }
 
 type TriggerResponse struct {
@@ -60,6 +61,7 @@ func Fire(p TriggerParameters) (string, error) {
 		IsAnonymous:  p.IsAnonymous,
 		Cost:         p.Cost,
 		Status:       p.Status,
+		StreamTitle:  p.StreamTitle,
 	}
 
 	e, err := types.GetByTriggerAndTransport(p.Event, p.Transport)

--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -26,7 +26,7 @@ type TriggerParameters struct {
 	Secret         string
 	Verbose        bool
 	Count          int
-	StreamTitle	   string
+	StreamTitle    string
 }
 
 type TriggerResponse struct {

--- a/internal/events/types/stream_change/stream_change_event.go
+++ b/internal/events/types/stream_change/stream_change_event.go
@@ -1,0 +1,123 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package stream_change
+
+import (
+	"encoding/json"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
+	"time"
+)
+
+var transportsSupported = map[string]bool{
+	models.TransportWebSub:   true,
+	models.TransportEventSub: true,
+}
+
+var triggerSupported = []string{"stream_change"}
+
+var triggerMapping = map[string]map[string]string{
+	models.TransportWebSub: {
+		"stream_change": "streams",
+	},
+	models.TransportEventSub: {
+		"stream_change": "channel.update",
+	},
+}
+
+type Event struct{}
+
+func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEventResponse, error) {
+	var event []byte
+	var err error
+
+	if params.StreamTitle == "" {
+		params.StreamTitle = "Default Title!"
+	}
+
+	switch params.Transport{
+	case models.TransportEventSub:
+		body := &models.EventsubResponse{
+			// make the eventsub response (if supported)
+			Subscription: models.EventsubSubscription{
+				ID:      params.ID,
+				Status:  "enabled",
+				Type:    "channel.update",
+				Version: "1",
+				Condition: models.EventsubCondition{
+					BroadcasterUserID: params.ToUserID,
+				},
+				Transport: models.EventsubTransport{
+					Method:   "webhook",
+					Callback: "null",
+				},
+				CreatedAt: util.GetTimestamp().Format(time.RFC3339Nano),
+			},
+			Event: models.ChannelUpdateEventSubEvent{
+				BroadcasterUserID:               params.ToUserID,
+				BroadcasterUserLogin:            params.ToUserID,
+				BroadcasterUserName:             params.ToUserName,
+				StreamTitle:    params.StreamTitle,
+				StreamLanguage: "en",
+				StreamCategoryID:  "509658",
+				StreamCategoryName:  "Just Chatting",
+				IsMature:  "true",
+			},
+		}
+		event, err = json.Marshal(body)
+		if err != nil {
+			return events.MockEventResponse{}, err
+		}
+	case models.TransportWebSub:
+		body := models.StreamChangeWebSubResponse{
+			Data: []models.StreamChangeWebSubResponseData{
+				{
+					WebsubID:     params.FromUserID,
+					BroadcasterUserID:   params.ToUserID,
+					BroadcasterUserLogin:       params.ToUserID,
+					BroadcasterUserName:     params.ToUserName,
+					StreamCategoryID: "509658",
+					StreamCategoryName:   "Just Chatting",
+					StreamType:       "live",
+					StreamTitle:     params.StreamTitle,
+					StreamViewerCount: 9848,
+					StreamStartedAt:   util.GetTimestamp().Format(time.RFC3339),
+					StreamLanguage:       "en",
+					StreamThumbnailURL:     "https://static-cdn.jtvnw.net/previews-ttv/live_user_lirik-{width}x{height}.jpg",
+				},
+			},
+		}
+		event, err = json.Marshal(body)
+		if err != nil {
+			return events.MockEventResponse{}, err
+		}
+	default:
+		return events.MockEventResponse{}, nil
+	}
+
+	return events.MockEventResponse{
+		ID:       params.ID,
+		JSON:     event,
+		FromUser: params.FromUserID,
+		ToUser:   params.ToUserID,
+	}, nil
+}
+
+func (e Event) ValidTransport(t string) bool {
+	return transportsSupported[t]
+}
+
+func (e Event) ValidTrigger(t string) bool {
+	for _, ts := range triggerSupported {
+		if ts == t {
+			return true
+		}
+	}
+	return false
+}
+
+func (e Event) GetTopic(transport string, trigger string) string {
+	return triggerMapping[transport][trigger]
+}

--- a/internal/events/types/stream_change/stream_change_event.go
+++ b/internal/events/types/stream_change/stream_change_event.go
@@ -17,7 +17,7 @@ var transportsSupported = map[string]bool{
 	models.TransportEventSub: true,
 }
 
-var triggerSupported = []string{"stream_change"}
+var triggerSupported = []string{"stream-change"}
 
 var triggerMapping = map[string]map[string]string{
 	models.TransportWebSub: {
@@ -35,7 +35,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	var err error
 
 	if params.StreamTitle == "" {
-		params.StreamTitle = "Default Title!"
+		params.StreamTitle = "Example title from the CLI!"
 	}
 
 	switch params.Transport {
@@ -86,7 +86,8 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 					StreamViewerCount:    9848,
 					StreamStartedAt:      util.GetTimestamp().Format(time.RFC3339),
 					StreamLanguage:       "en",
-					StreamThumbnailURL:   "https://static-cdn.jtvnw.net/previews-ttv/live_user_lirik-{width}x{height}.jpg",
+					StreamThumbnailURL:   "https://static-cdn.jtvnw.net/previews-ttv/live_twitch_user-{width}x{height}.jpg",
+					TagIDs:				  make([]string, 0),
 				},
 			},
 		}

--- a/internal/events/types/stream_change/stream_change_event.go
+++ b/internal/events/types/stream_change/stream_change_event.go
@@ -5,10 +5,11 @@ package stream_change
 import (
 	"encoding/json"
 
+	"time"
+
 	"github.com/twitchdev/twitch-cli/internal/events"
 	"github.com/twitchdev/twitch-cli/internal/models"
 	"github.com/twitchdev/twitch-cli/internal/util"
-	"time"
 )
 
 var transportsSupported = map[string]bool{
@@ -37,7 +38,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 		params.StreamTitle = "Default Title!"
 	}
 
-	switch params.Transport{
+	switch params.Transport {
 	case models.TransportEventSub:
 		body := &models.EventsubResponse{
 			// make the eventsub response (if supported)
@@ -56,14 +57,14 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				CreatedAt: util.GetTimestamp().Format(time.RFC3339Nano),
 			},
 			Event: models.ChannelUpdateEventSubEvent{
-				BroadcasterUserID:               params.ToUserID,
-				BroadcasterUserLogin:            params.ToUserID,
-				BroadcasterUserName:             params.ToUserName,
-				StreamTitle:    params.StreamTitle,
-				StreamLanguage: "en",
-				StreamCategoryID:  "509658",
-				StreamCategoryName:  "Just Chatting",
-				IsMature:  "true",
+				BroadcasterUserID:    params.ToUserID,
+				BroadcasterUserLogin: params.ToUserID,
+				BroadcasterUserName:  params.ToUserName,
+				StreamTitle:          params.StreamTitle,
+				StreamLanguage:       "en",
+				StreamCategoryID:     "509658",
+				StreamCategoryName:   "Just Chatting",
+				IsMature:             "true",
 			},
 		}
 		event, err = json.Marshal(body)
@@ -74,18 +75,18 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 		body := models.StreamChangeWebSubResponse{
 			Data: []models.StreamChangeWebSubResponseData{
 				{
-					WebsubID:     params.FromUserID,
-					BroadcasterUserID:   params.ToUserID,
-					BroadcasterUserLogin:       params.ToUserID,
-					BroadcasterUserName:     params.ToUserName,
-					StreamCategoryID: "509658",
+					WebsubID:             params.FromUserID,
+					BroadcasterUserID:    params.ToUserID,
+					BroadcasterUserLogin: params.ToUserID,
+					BroadcasterUserName:  params.ToUserName,
+					StreamCategoryID:     "509658",
 					StreamCategoryName:   "Just Chatting",
-					StreamType:       "live",
-					StreamTitle:     params.StreamTitle,
-					StreamViewerCount: 9848,
-					StreamStartedAt:   util.GetTimestamp().Format(time.RFC3339),
+					StreamType:           "live",
+					StreamTitle:          params.StreamTitle,
+					StreamViewerCount:    9848,
+					StreamStartedAt:      util.GetTimestamp().Format(time.RFC3339),
 					StreamLanguage:       "en",
-					StreamThumbnailURL:     "https://static-cdn.jtvnw.net/previews-ttv/live_user_lirik-{width}x{height}.jpg",
+					StreamThumbnailURL:   "https://static-cdn.jtvnw.net/previews-ttv/live_user_lirik-{width}x{height}.jpg",
 				},
 			},
 		}

--- a/internal/events/types/stream_change/stream_change_event_test.go
+++ b/internal/events/types/stream_change/stream_change_event_test.go
@@ -21,7 +21,7 @@ func TestEventSub(t *testing.T) {
 		FromUserID: fromUser,
 		ToUserID:   toUser,
 		Transport:  models.TransportEventSub,
-		Trigger:    "stream_change",
+		Trigger:    "stream-change",
 	}
 
 	r, err := Event{}.GenerateEvent(params)
@@ -49,19 +49,19 @@ func TestEventSub(t *testing.T) {
 	a.Nil(err)
 
 	a.Equal(toUser, body.Event.BroadcasterUserID, "Expected Stream Channel %v, got %v", toUser, body.Event.BroadcasterUserID)
-	a.Equal("Default Title!", body.Event.StreamTitle, "Expected new stream title, got %v", body.Event.StreamTitle)
+	a.Equal("Example title from the CLI!", body.Event.StreamTitle, "Expected new stream title, got %v", body.Event.StreamTitle)
 }
 
 func TestWebSubStreamChange(t *testing.T) {
 	a := util.SetupTestEnv(t)
 
-	newStreamTitle := "Awesome new title!"
+	newStreamTitle := "Awesome new title from the CLI!"
 
 	params := *&events.MockEventParameters{
 		FromUserID:  fromUser,
 		ToUserID:    toUser,
 		Transport:   models.TransportWebSub,
-		Trigger:     "stream_change",
+		Trigger:     "stream-change",
 		StreamTitle: newStreamTitle,
 	}
 
@@ -83,7 +83,7 @@ func TestFakeTransport(t *testing.T) {
 		FromUserID: fromUser,
 		ToUserID:   toUser,
 		Transport:  "fake_transport",
-		Trigger:    "stream_change",
+		Trigger:    "stream-change",
 	}
 
 	r, err := Event{}.GenerateEvent(params)
@@ -93,7 +93,7 @@ func TestFakeTransport(t *testing.T) {
 func TestValidTrigger(t *testing.T) {
 	a := util.SetupTestEnv(t)
 
-	r := Event{}.ValidTrigger("stream_change")
+	r := Event{}.ValidTrigger("stream-change")
 	a.Equal(true, r)
 
 	r = Event{}.ValidTrigger("not_trigger_keyword")
@@ -112,6 +112,6 @@ func TestValidTransport(t *testing.T) {
 func TestGetTopic(t *testing.T) {
 	a := util.SetupTestEnv(t)
 
-	r := Event{}.GetTopic(models.TransportEventSub, "stream_change")
+	r := Event{}.GetTopic(models.TransportEventSub, "stream-change")
 	a.NotNil(r)
 }

--- a/internal/events/types/stream_change/stream_change_event_test.go
+++ b/internal/events/types/stream_change/stream_change_event_test.go
@@ -1,0 +1,117 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package stream_change
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
+)
+
+var fromUser = "1234"
+var toUser = "4567"
+
+func TestEventSub(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportEventSub,
+		Trigger:    "stream_change",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.ChannelUpdateEventSubResponse
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err, "Error unmarshalling JSON")
+
+	// write actual tests here (making sure you set appropriate values and the like) for eventsub
+	a.Equal(toUser, body.Event.BroadcasterUserID, "Expected Stream Channel %v, got %v", toUser, body.Event.BroadcasterUserID)
+
+	// test for changing a title
+	params = events.MockEventParameters{
+		FromUserID:  fromUser,
+		ToUserID:    toUser,
+		Transport:   models.TransportEventSub,
+		Trigger:     "stream_change",
+	}
+
+	r, err = Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	a.Equal(toUser, body.Event.BroadcasterUserID, "Expected Stream Channel %v, got %v", toUser, body.Event.BroadcasterUserID)
+	a.Equal("Default Title!", body.Event.StreamTitle, "Expected new stream title, got %v", body.Event.StreamTitle)
+}
+
+func TestWebSubStreamChange(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	newStreamTitle := "Awesome new title!"
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportWebSub,
+		Trigger:    "stream_change",
+		StreamTitle: newStreamTitle,
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.StreamChangeWebSubResponse
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	// write tests here for websub
+	a.Equal(toUser, body.Data[0].BroadcasterUserID, "Expected Stream Channel %v, got %v", toUser, body.Data[0].BroadcasterUserID)
+	a.Equal(newStreamTitle, body.Data[0].StreamTitle, "Expected new stream title, got %v", body.Data[0].StreamTitle)
+}
+func TestFakeTransport(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  "fake_transport",
+		Trigger:    "stream_change",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+	a.Empty(r)
+}
+func TestValidTrigger(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	r := Event{}.ValidTrigger("stream_change")
+	a.Equal(true, r)
+
+	r = Event{}.ValidTrigger("not_trigger_keyword")
+	a.Equal(false, r)
+}
+
+func TestValidTransport(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	r := Event{}.ValidTransport(models.TransportEventSub)
+	a.Equal(true, r)
+
+	r = Event{}.ValidTransport("noteventsub")
+	a.Equal(false, r)
+}
+func TestGetTopic(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	r := Event{}.GetTopic(models.TransportEventSub, "stream_change")
+	a.NotNil(r)
+}

--- a/internal/events/types/stream_change/stream_change_event_test.go
+++ b/internal/events/types/stream_change/stream_change_event_test.go
@@ -36,10 +36,10 @@ func TestEventSub(t *testing.T) {
 
 	// test for changing a title
 	params = events.MockEventParameters{
-		FromUserID:  fromUser,
-		ToUserID:    toUser,
-		Transport:   models.TransportEventSub,
-		Trigger:     "stream_change",
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportEventSub,
+		Trigger:    "stream_change",
 	}
 
 	r, err = Event{}.GenerateEvent(params)
@@ -58,10 +58,10 @@ func TestWebSubStreamChange(t *testing.T) {
 	newStreamTitle := "Awesome new title!"
 
 	params := *&events.MockEventParameters{
-		FromUserID: fromUser,
-		ToUserID:   toUser,
-		Transport:  models.TransportWebSub,
-		Trigger:    "stream_change",
+		FromUserID:  fromUser,
+		ToUserID:    toUser,
+		Transport:   models.TransportWebSub,
+		Trigger:     "stream_change",
 		StreamTitle: newStreamTitle,
 	}
 

--- a/internal/events/types/types.go
+++ b/internal/events/types/types.go
@@ -14,6 +14,7 @@ import (
 	"github.com/twitchdev/twitch-cli/internal/events/types/follow"
 	"github.com/twitchdev/twitch-cli/internal/events/types/moderator_change"
 	"github.com/twitchdev/twitch-cli/internal/events/types/raid"
+	"github.com/twitchdev/twitch-cli/internal/events/types/stream_change"
 	"github.com/twitchdev/twitch-cli/internal/events/types/streamdown"
 	"github.com/twitchdev/twitch-cli/internal/events/types/streamup"
 	"github.com/twitchdev/twitch-cli/internal/events/types/subscribe"
@@ -29,6 +30,7 @@ func All() []events.MockEvent {
 		follow.Event{},
 		raid.Event{},
 		subscribe.Event{},
+		stream_change.Event{},
 		streamup.Event{},
 		streamdown.Event{},
 		moderator_change.Event{},

--- a/internal/models/stream_change.go
+++ b/internal/models/stream_change.go
@@ -6,34 +6,34 @@ type ChannelUpdateEventSubEvent struct {
 	BroadcasterUserID    string `json:"broadcaster_user_id"`
 	BroadcasterUserLogin string `json:"broadcaster_user_login"`
 	BroadcasterUserName  string `json:"broadcaster_user_name"`
-	StreamTitle    		 string `json:"title"`
-	StreamLanguage		 string `json:"language"`
+	StreamTitle          string `json:"title"`
+	StreamLanguage       string `json:"language"`
 	StreamCategoryID     string `json:"category_id"`
 	StreamCategoryName   string `json:"category_name"`
-	IsMature 			 string `json:"is_mature"`
+	IsMature             string `json:"is_mature"`
 }
 
 type StreamChangeWebSubResponse struct {
-	Data []StreamChangeWebSubResponseData `json:"data"`	
+	Data []StreamChangeWebSubResponseData `json:"data"`
 }
 
 type StreamChangeWebSubResponseData struct {
-	WebsubID     			string `json:"id"`
-	BroadcasterUserID   	string `json:"user_id"`
-	BroadcasterUserLogin    string `json:"user_login"`
-	BroadcasterUserName 	string `json:"user_name"`
-	StreamCategoryID    	string `json:"game_id"`
-	StreamCategoryName    	string `json:"game_name"`
-	StreamType       		string `json:"type"`
-	StreamTitle     		string `json:"title"`
-	StreamViewerCount 		int    `json:"viewer_count"`
-	StreamStartedAt     	string `json:"started_at"`
-	StreamLanguage     	 	string `json:"language"`
-	StreamThumbnailURL 	 	string `json:"thumbnail_url"`
-	TagIDs 					[]string `json:"tag_ids"`
+	WebsubID             string   `json:"id"`
+	BroadcasterUserID    string   `json:"user_id"`
+	BroadcasterUserLogin string   `json:"user_login"`
+	BroadcasterUserName  string   `json:"user_name"`
+	StreamCategoryID     string   `json:"game_id"`
+	StreamCategoryName   string   `json:"game_name"`
+	StreamType           string   `json:"type"`
+	StreamTitle          string   `json:"title"`
+	StreamViewerCount    int      `json:"viewer_count"`
+	StreamStartedAt      string   `json:"started_at"`
+	StreamLanguage       string   `json:"language"`
+	StreamThumbnailURL   string   `json:"thumbnail_url"`
+	TagIDs               []string `json:"tag_ids"`
 }
 
 type ChannelUpdateEventSubResponse struct {
-	Subscription EventsubSubscription `json:"subscription"`
-	Event        ChannelUpdateEventSubEvent  `json:"event"`
+	Subscription EventsubSubscription       `json:"subscription"`
+	Event        ChannelUpdateEventSubEvent `json:"event"`
 }

--- a/internal/models/stream_change.go
+++ b/internal/models/stream_change.go
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package models
+
+type ChannelUpdateEventSubEvent struct {
+	BroadcasterUserID    string `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	BroadcasterUserName  string `json:"broadcaster_user_name"`
+	StreamTitle    		 string `json:"title"`
+	StreamLanguage		 string `json:"language"`
+	StreamCategoryID     string `json:"category_id"`
+	StreamCategoryName   string `json:"category_name"`
+	IsMature 			 string `json:"is_mature"`
+}
+
+type StreamChangeWebSubResponse struct {
+	Data []StreamChangeWebSubResponseData `json:"data"`	
+}
+
+type StreamChangeWebSubResponseData struct {
+	WebsubID     			string `json:"id"`
+	BroadcasterUserID   	string `json:"user_id"`
+	BroadcasterUserLogin    string `json:"user_login"`
+	BroadcasterUserName 	string `json:"user_name"`
+	StreamCategoryID    	string `json:"game_id"`
+	StreamCategoryName    	string `json:"game_name"`
+	StreamType       		string `json:"type"`
+	StreamTitle     		string `json:"title"`
+	StreamViewerCount 		int    `json:"viewer_count"`
+	StreamStartedAt     	string `json:"started_at"`
+	StreamLanguage     	 	string `json:"language"`
+	StreamThumbnailURL 	 	string `json:"thumbnail_url"`
+	TagIDs 					[]string `json:"tag_ids"`
+}
+
+type ChannelUpdateEventSubResponse struct {
+	Subscription EventsubSubscription `json:"subscription"`
+	Event        ChannelUpdateEventSubEvent  `json:"event"`
+}


### PR DESCRIPTION
Adding support for "stream_change" websub and eventsub.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Adding Websub and Eventsub spoofing support for "stream_change" topic. 

## Description of Changes: 

twitch event trigger stream_change -d "Title Update" to simulate the updating of a channel's stream title

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [not yet but I will] I have updated the documentation (if applicable)
