### PR TITLE
Stream up down events

### DIFF
--- a/docs/event.md
+++ b/docs/event.md
@@ -31,8 +31,8 @@ Used to either create or send mock events for use with local webhooks testing.
 | `raid`              | Channel Raid event with a random viewer count.                                                             |
 | `revoke`            | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly. |
 | `stream-change`     | Stream Changed event.                                                                                      |
-| `streamup`          | Only usable with the `eventsub` transport, a stream online event.                                          |
-| `streamdown`        | Only usable with the `eventsub` transport, a stream offline event.                                         |
+| `streamup`          | Stream online event.                                          |
+| `streamdown`        | Sstream offline event.                                         |
 | `add-moderator`     | Channel moderator add event.                                                                               |
 | `remove-moderator`  | Channel moderator removal event.                                                                           |
 
@@ -51,7 +51,7 @@ Used to either create or send mock events for use with local webhooks testing.
 | `--status`          | `-S`      | Status of the event object, currently applies to channel points redemptions.                                               | `-S fulfilled`                            | N               |
 | `--item-id`         | `-i`      | Manually set the ID of the event payload item (for example the reward ID in redemption events).                            | `-i 032e4a6c-4aef-11eb-a9f5-1f703d1f0b92` | N               |
 | `--cost`            | `-C`      | Amount of bits or channel points redeemed/used in the event.                                                               | `-C 250`                                  | N               |
-| `--description`            | `-d`      | Title the stream should be updated with.                                                                            | `-d Awesome new title!`                                  | N               |
+| `--description`            | `-d`      | Title the stream should be updated/started with.                                                                            | `-d Awesome new title!`                                  | N               |
 
 **Examples**
 
@@ -116,8 +116,8 @@ Allows you to test if your webserver responds to subscription requests properly.
 | `raid`              | Channel Raid event with a random viewer count.                                                             |
 | `revoke`            | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly. |
 | `stream_change`     | Stream changed event.                                                                                      |
-| `streamup`          | Only usable with the `eventsub` transport, a stream online event.                                          |
-| `streamdown`        | Only usable with the `eventsub` transport, a stream offline event.                                         |
+| `streamup`          | Stream online event.                                          |
+| `streamdown`        | Stream offline event.                                         |
 | `add-moderator`     | Channel moderator add event.                                                                               |
 | `remove-moderator`  | Channel moderator removal event.                                                                           |
 

--- a/internal/events/types/streamdown/streamdown.go
+++ b/internal/events/types/streamdown/streamdown.go
@@ -12,7 +12,7 @@ import (
 )
 
 var transportsSupported = map[string]bool{
-	models.TransportWebSub:   false,
+	models.TransportWebSub:   true,
 	models.TransportEventSub: true,
 }
 
@@ -56,6 +56,15 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				BroadcasterUserName:  params.ToUserName,
 			},
 		}
+		event, err = json.Marshal(body)
+		if err != nil {
+			return events.MockEventResponse{}, err
+		}
+	case models.TransportWebSub:
+		body := *&models.StreamDownWebSubResponse{
+			Data: []models.StreamDownWebSubResponseData{	
+			}}
+
 		event, err = json.Marshal(body)
 		if err != nil {
 			return events.MockEventResponse{}, err

--- a/internal/events/types/streamdown/streamdown_test.go
+++ b/internal/events/types/streamdown/streamdown_test.go
@@ -34,6 +34,26 @@ func TestEventSub(t *testing.T) {
 	// write actual tests here (making sure you set appropriate values and the like) for eventsub
 }
 
+func TestWebSub(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportWebSub,
+		Trigger:    "streamdown",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.StreamDownWebSubResponse
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	// write tests here for websub
+}
+
 func TestFakeTransport(t *testing.T) {
 	a := util.SetupTestEnv(t)
 

--- a/internal/events/types/streamup/streamup.go
+++ b/internal/events/types/streamup/streamup.go
@@ -12,7 +12,7 @@ import (
 )
 
 var transportsSupported = map[string]bool{
-	models.TransportWebSub:   false,
+	models.TransportWebSub:   true,
 	models.TransportEventSub: true,
 }
 
@@ -32,6 +32,10 @@ type Event struct{}
 func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEventResponse, error) {
 	var event []byte
 	var err error
+
+	if params.StreamTitle == "" {
+		params.StreamTitle = "Example title from the CLI!"
+	}
 
 	switch params.Transport {
 	case models.TransportEventSub:
@@ -59,6 +63,29 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				StartedAt:            util.GetTimestamp().Format(time.RFC3339Nano),
 			},
 		}
+		event, err = json.Marshal(body)
+		if err != nil {
+			return events.MockEventResponse{}, err
+		}
+	case models.TransportWebSub:
+		body := models.StreamUpWebSubResponse{
+			Data: []models.StreamUpWebSubResponseData{
+				{
+			ID: params.ID,
+			UserID: params.ToUserID,
+			UserName: params.ToUserName,
+			GameID: "509658",
+			CommunityIDs: make([]string, 0),
+			Type: "live",
+			Title: params.StreamTitle,
+			ViewerCount: 1337,
+			StartedAt: util.GetTimestamp().Format(time.RFC3339),
+			Language: "en",
+			ThumbnailURL: "https://static-cdn.jtvnw.net/ttv-static/404_preview-440x248.jpg",
+			},
+		},
+		}
+
 		event, err = json.Marshal(body)
 		if err != nil {
 			return events.MockEventResponse{}, err

--- a/internal/events/types/streamup/streamup.go
+++ b/internal/events/types/streamup/streamup.go
@@ -73,15 +73,16 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				{
 			ID: params.ID,
 			UserID: params.ToUserID,
+			UserLogin: params.ToUserName,
 			UserName: params.ToUserName,
 			GameID: "509658",
-			CommunityIDs: make([]string, 0),
 			Type: "live",
 			Title: params.StreamTitle,
 			ViewerCount: 1337,
 			StartedAt: util.GetTimestamp().Format(time.RFC3339),
 			Language: "en",
 			ThumbnailURL: "https://static-cdn.jtvnw.net/ttv-static/404_preview-440x248.jpg",
+			TagIDs: make([]string, 0),
 			},
 		},
 		}

--- a/internal/events/types/streamup/streamup_test.go
+++ b/internal/events/types/streamup/streamup_test.go
@@ -34,6 +34,26 @@ func TestEventSub(t *testing.T) {
 	// write actual tests here (making sure you set appropriate values and the like) for eventsub
 }
 
+func TestWebSub(t *testing.T) {
+	a := util.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportWebSub,
+		Trigger:    "unsubscribe",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.StreamUpWebSubResponse
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	// write tests here for websub
+}
+
 func TestFakeTransport(t *testing.T) {
 	a := util.SetupTestEnv(t)
 

--- a/internal/models/streamdown.go
+++ b/internal/models/streamdown.go
@@ -12,3 +12,10 @@ type StreamDownEventSubEvent struct {
 	BroadcasterUserLogin string `json:"broadcaster_user_login"`
 	BroadcasterUserName  string `json:"broadcaster_user_name"`
 }
+
+type StreamDownWebSubResponse struct {
+	Data []StreamDownWebSubResponseData `json:"data"`
+}
+
+type StreamDownWebSubResponseData struct {
+}

--- a/internal/models/streamup.go
+++ b/internal/models/streamup.go
@@ -23,13 +23,14 @@ type StreamUpWebSubResponse struct {
 type StreamUpWebSubResponseData struct {
 	ID    			string  	`json:"id"`
 	UserID  		string  	`json:"user_id"`
+	UserLogin  		string  	`json:"user_login"`
 	UserName  		string  	`json:"user_name"`
 	GameID  		string  	`json:"game_id"`
-	CommunityIDs	[]string  	`json:"community_ids"`
 	Type    		string 		`json:"type"`
 	Title    		string 		`json:"title"`
 	ViewerCount     int64       `json:"viewer_count"`
 	StartedAt       string 		`json:"started_at"`
 	Language 		string 		`json:language`
 	ThumbnailURL 	string 		`json:thumbnail_url`
+	TagIDs			[]string  	`json:"tag_ids"`
 }

--- a/internal/models/streamup.go
+++ b/internal/models/streamup.go
@@ -15,3 +15,21 @@ type StreamUpEventSubEvent struct {
 	Type                 string `json:"type"`
 	StartedAt            string `json:"started_at"`
 }
+
+type StreamUpWebSubResponse struct {
+	Data []StreamUpWebSubResponseData `json:"data"`
+}
+
+type StreamUpWebSubResponseData struct {
+	ID    			string  	`json:"id"`
+	UserID  		string  	`json:"user_id"`
+	UserName  		string  	`json:"user_name"`
+	GameID  		string  	`json:"game_id"`
+	CommunityIDs	[]string  	`json:"community_ids"`
+	Type    		string 		`json:"type"`
+	Title    		string 		`json:"title"`
+	ViewerCount     int64       `json:"viewer_count"`
+	StartedAt       string 		`json:"started_at"`
+	Language 		string 		`json:language`
+	ThumbnailURL 	string 		`json:thumbnail_url`
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Complete Stream Up/Down support by adding Websub support

## Description of Changes: 

- Added a new case on the Transport switch of the streamdown event to support WebSub.
- Created a new StreamDownWebSubResponse model to support the above case.
- Added a new case to the Transport switch of the streamup event to support Websub.
- Created a new StreamUpWebSubResponse model for the above.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)