### PR TITLE
updating build process to add HEAD + M1 support, addressing #52

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,10 +63,34 @@ brews:
     folder: Formula
     homepage: https://github.com/twitchdev/twitch-cli
     description: CLI for Twitch's developer offerings
+    custom_block: | 
+      if OS.mac? && Hardware::CPU.arm?
+        url "https://github.com/twitchdev/twitch-cli.git", tag: "{{ .Tag }}"
+        depends_on "go" => :build
+      end
+
+      head "https://github.com/twitchdev/twitch-cli.git", branch: "main"
+      head do
+        depends_on "go" => :build
+      end
     install: |
+      v = version
+      if build.head? 
+        v = "head"
+        ldflags = "-X main.buildVersion=#{v}"
+        system "go", "build", "-ldflags=#{ldflags}"
+        mv "twitch-cli", "twitch"
+      end
+
+      if OS.mac? && Hardware::CPU.arm? 
+        ldflags = "-X main.buildVersion=#{v}"
+        system "go", "build", "-ldflags=#{ldflags}"
+        mv "twitch-cli", "twitch"
+      end
+      
       bin.install "twitch"
     test: |
-      system "#{bin}/twitch -v"
+      system "#{bin}/twitch", "version"
     license: Apache-2.0
 archives:
   - replacements:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,15 @@ release:
 		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
 		twitch-cli:latest --rm-dist
 
+test-release:
+	docker build . -t twitch-cli:latest
+	docker run --rm --privileged \
+		-v $$PWD:/go/src/github.com/twitchdev/twitch-cli \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-w /go/src/github.com/twitchdev/twitch-cli \
+		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
+		twitch-cli:latest --rm-dist --skip-publish --snapshot
+	
 build:
 	go build --ldflags "-X main.buildVersion=source"
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

#52 Identified that M1 support was broken, so this PR introduces a temporary fix until CGO is no longer needed. 

## Description of Changes: 

- Adds support for both a HEAD and M1 release, meaning that Brew now supports both bleeding edge clients (using --head in the install flags) as well as M1 via local building

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
