### PR TITLE
EventSub: followed_at

### DIFF
--- a/internal/events/types/follow/follow_event.go
+++ b/internal/events/types/follow/follow_event.go
@@ -57,6 +57,7 @@ func (e Event) GenerateEvent(p events.MockEventParameters) (events.MockEventResp
 				BroadcasterUserID:    p.ToUserID,
 				BroadcasterUserLogin: p.ToUserID,
 				BroadcasterUserName:  p.ToUserName,
+				FollowedAt:           util.GetTimestamp().Format(time.RFC3339Nano),
 			},
 		}
 

--- a/internal/models/follow.go
+++ b/internal/models/follow.go
@@ -8,7 +8,7 @@ type FollowEventSubEvent struct {
 	UserName             string `json:"user_name"`
 	BroadcasterUserID    string `json:"broadcaster_user_id"`
 	BroadcasterUserLogin string `json:"broadcaster_user_login"`
-	BroadcasterUserName  string `json:"broadcaster_user_name"`,
+	BroadcasterUserName  string `json:"broadcaster_user_name"`
         FollowedAt           string `json:"followed_at"`
 }
 

--- a/internal/models/follow.go
+++ b/internal/models/follow.go
@@ -8,7 +8,8 @@ type FollowEventSubEvent struct {
 	UserName             string `json:"user_name"`
 	BroadcasterUserID    string `json:"broadcaster_user_id"`
 	BroadcasterUserLogin string `json:"broadcaster_user_login"`
-	BroadcasterUserName  string `json:"broadcaster_user_name"`
+	BroadcasterUserName  string `json:"broadcaster_user_name"`,
+        FollowedAt           string `json:"followed_at"`
 }
 
 type FollowWebSubResponse struct {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

followed_at was added to event sub for follow events but is not reflected in the CLI

## Description of Changes: 

Add `followed_at` to the follow EventSub

- Update the Models/follow
- Update the events/follow_event

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
