### PR TITLE
fix field for seconds in global_cooldown

### DIFF
--- a/internal/events/types/channel_points_reward/reward_event.go
+++ b/internal/events/types/channel_points_reward/reward_event.go
@@ -81,7 +81,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				},
 				GlobalCooldown: models.RewardGlobalCooldown{
 					IsEnabled: true,
-					Value:     300,
+					Seconds:   300,
 				},
 				BackgroundColor: "#c0ffee",
 				Image: models.RewardImage{

--- a/internal/models/reward.go
+++ b/internal/models/reward.go
@@ -32,7 +32,7 @@ type RewardMax struct {
 
 type RewardGlobalCooldown struct {
 	IsEnabled bool  `json:"is_enabled"`
-	Value     int64 `json:"value"`
+	Seconds   int64 `json:"seconds"`
 }
 
 type RewardImage struct {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

`RewardGlobalCooldown` used `value` as its seconds field. This changes it to be the correct value `seconds`

## Description of Changes: 

- Change `RewardGlobalCooldown.value` -> `RewardGlobalCooldown.seconds`

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
