### PR TITLE
Fixes #60 and adds a new "item-name" flag to allow for the item name to be set.

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -24,9 +24,10 @@ var (
 	secret         string
 	status         string
 	itemID         string
+	itemName       string
 	cost           int64
 	count          int
-	streamTitle	   string
+	description    string
 )
 
 var eventCmd = &cobra.Command{
@@ -73,18 +74,22 @@ func init() {
 	eventCmd.AddCommand(triggerCmd, retriggerCmd, verifyCmd)
 
 	// trigger flags
+	// flags for forwarding functionality/changing payloads
 	triggerCmd.Flags().StringVarP(&forwardAddress, "forward-address", "F", "", "Forward address for mock event.")
-	triggerCmd.Flags().StringVarP(&transport, "transport", "T", "eventsub", fmt.Sprintf("Preferred transport method for event. Defaults to Webhooks 2/EventSub.\nSupported values: %s", events.ValidTransports()))
+	triggerCmd.Flags().StringVarP(&transport, "transport", "T", "eventsub", fmt.Sprintf("Preferred transport method for event. Defaults to /EventSub.\nSupported values: %s", events.ValidTransports()))
+	triggerCmd.Flags().StringVarP(&secret, "secret", "s", "", "Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC.")
+
+	// per-topic flags
 	triggerCmd.Flags().StringVarP(&toUser, "to-user", "t", "", "User ID of the receiver of the event. For example, the user that receives a follow. In most contexts, this is the broadcaster.")
 	triggerCmd.Flags().StringVarP(&fromUser, "from-user", "f", "", "User ID of the user sending the event, for example the user following another user.")
 	triggerCmd.Flags().StringVarP(&giftUser, "gift-user", "g", "", "Used only for \"gift\" events. Denotes the User ID of the gifting user.")
 	triggerCmd.Flags().BoolVarP(&isAnonymous, "anonymous", "a", false, "Denotes if the event is anonymous. Only applies to Gift and Sub events.")
 	triggerCmd.Flags().IntVarP(&count, "count", "c", 1, "Count of events to events. This will simulate a sub gift, or large number of cheers.")
-	triggerCmd.Flags().StringVarP(&secret, "secret", "s", "", "Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC.")
 	triggerCmd.Flags().StringVarP(&status, "status", "S", "", "Status of the event object, currently applies to channel points redemptions.")
-	triggerCmd.Flags().StringVarP(&itemID, "item-id", "i", "", "Manually set the ID of the event payload item (for example the reward ID in redemption events).")
+	triggerCmd.Flags().StringVarP(&itemID, "item-id", "i", "", "Manually set the ID of the event payload item (for example the reward ID in redemption events). For stream events, this is the game ID.")
+	triggerCmd.Flags().StringVarP(&itemName, "item-name", "n", "", "Manually set the name of the event payload item (for example the reward ID in redemption events). For stream events, this is the game title.")
 	triggerCmd.Flags().Int64VarP(&cost, "cost", "C", 0, "Amount of bits or channel points redeemed/used in the event.")
-	triggerCmd.Flags().StringVarP(&streamTitle, "description", "d", "", "Title the stream should be updated with.")
+	triggerCmd.Flags().StringVarP(&description, "description", "d", "", "Title the stream should be updated with.")
 
 	// retrigger flags
 	retriggerCmd.Flags().StringVarP(&forwardAddress, "forward-address", "F", "", "Forward address for mock event.")
@@ -94,7 +99,7 @@ func init() {
 
 	// verify-subscription flags
 	verifyCmd.Flags().StringVarP(&forwardAddress, "forward-address", "F", "", "Forward address for mock event.")
-	verifyCmd.Flags().StringVarP(&transport, "transport", "T", "eventsub", fmt.Sprintf("Preferred transport method for event. Defaults to Webhooks 2/EventSub.\nSupported values: %s", events.ValidTransports()))
+	verifyCmd.Flags().StringVarP(&transport, "transport", "T", "eventsub", fmt.Sprintf("Preferred transport method for event. Defaults to EventSub.\nSupported values: %s", events.ValidTransports()))
 	verifyCmd.Flags().StringVarP(&secret, "secret", "s", "", "Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC.")
 	verifyCmd.MarkFlagRequired("forward-address")
 }
@@ -127,7 +132,8 @@ func triggerCmdRun(cmd *cobra.Command, args []string) {
 			Status:         status,
 			ItemID:         itemID,
 			Cost:           cost,
-			StreamTitle:	streamTitle,
+			Description:    description,
+			ItemName:       itemName,
 		})
 
 		if err != nil {

--- a/docs/event.md
+++ b/docs/event.md
@@ -45,20 +45,22 @@ Used to either create or send mock events for use with local webhooks testing.
 
 **Flags**
 
-| Flag                | Shorthand | Description                                                                                                                | Example                                   | Required? (Y/N) |
-| ------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | --------------- |
-| `--forward-address` | `-F`      | Web server address for where to send mock events.                                                                          | `-F https://localhost:8080`               | N               |
-| `--transport`       | `-T`      | The method used to send events. Default is eventsub, but can send using websub.                                            | `-T websub`                               | N               |
-| `--to-user`         | `-t`      | Denotes the receiver's TUID of the event, usually the broadcaster.                                                         | `-t 44635596`                             | N               |
-| `--from-user`       | `-f`      | Denotes the sender's TUID of the event, for example the user that follows another user or the subscriber to a broadcaster. | `-f 44635596`                             | N               |
-| `--gift-user`       | `-g`      | Used only for subcription-based events, denotes the gifting user ID                                                        | `-g 44635596`                             | N               |
-| `--secret`          | `-s`      | Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC.                                               | `-s testsecret`                           | N               |
-| `--count`           | `-c`      | Count of events to fire. This can be used to simulate an influx of subscriptions.                                          | `-c 100`                                  | N               |
-| `--anonymous`       | `-a`      | If the event is anonymous. Only applies to `gift` and `cheer` events.                                                      | `-a`                                      | N               |
-| `--status`          | `-S`      | Status of the event object, currently applies to channel points redemptions.                                               | `-S fulfilled`                            | N               |
-| `--item-id`         | `-i`      | Manually set the ID of the event payload item (for example the reward ID in redemption events).                            | `-i 032e4a6c-4aef-11eb-a9f5-1f703d1f0b92` | N               |
-| `--cost`            | `-C`      | Amount of bits or channel points redeemed/used in the event.                                                               | `-C 250`                                  | N               |
-| `--description`            | `-d`      | Title the stream should be updated/started with.                                                                            | `-d Awesome new title!`                                  | N               |
+| Flag                | Shorthand | Description                                                                                                                     | Example                                   | Required? (Y/N) |
+|---------------------|-----------|---------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|-----------------|
+| `--forward-address` | `-F`      | Web server address for where to send mock events.                                                                               | `-F https://localhost:8080`               | N               |
+| `--transport`       | `-T`      | The method used to send events. Default is eventsub, but can send using websub.                                                 | `-T websub`                               | N               |
+| `--to-user`         | `-t`      | Denotes the receiver's TUID of the event, usually the broadcaster.                                                              | `-t 44635596`                             | N               |
+| `--from-user`       | `-f`      | Denotes the sender's TUID of the event, for example the user that follows another user or the subscriber to a broadcaster.      | `-f 44635596`                             | N               |
+| `--gift-user`       | `-g`      | Used only for subcription-based events, denotes the gifting user ID                                                             | `-g 44635596`                             | N               |
+| `--secret`          | `-s`      | Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC.                                                    | `-s testsecret`                           | N               |
+| `--count`           | `-c`      | Count of events to fire. This can be used to simulate an influx of subscriptions.                                               | `-c 100`                                  | N               |
+| `--anonymous`       | `-a`      | If the event is anonymous. Only applies to `gift` and `cheer` events.                                                           | `-a`                                      | N               |
+| `--status`          | `-S`      | Status of the event object, currently applies to channel points redemptions.                                                    | `-S fulfilled`                            | N               |
+| `--item-id`         | `-i`      | Manually set the ID of the event payload item (for example the reward ID in redemption events or game in stream events).        | `-i 032e4a6c-4aef-11eb-a9f5-1f703d1f0b92` | N               |
+| `--item-name`       | `-n`      | Manually set the name of the event payload item (for example the reward ID in redemption events or game name in stream events). | `-n "Science & Technology"`               | N               |
+| `--cost`            | `-C`      | Amount of bits or channel points redeemed/used in the event.                                                                    | `-C 250`                                  | N               |
+| `--description`     | `-d`      | Title the stream should be updated/started with.                                                                                | `-d Awesome new title!`                   | N               |
+
 
 **Examples**
 

--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -16,9 +16,10 @@ type MockEventParameters struct {
 	IsGift       bool
 	Status       string
 	ItemID       string
+	ItemName     string
 	Cost         int64
 	IsPermanent  bool
-	StreamTitle  string
+	Description  string
 }
 
 type MockEventResponse struct {

--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -26,7 +26,8 @@ type TriggerParameters struct {
 	Secret         string
 	Verbose        bool
 	Count          int
-	StreamTitle    string
+	Description    string
+	ItemName       string
 }
 
 type TriggerResponse struct {
@@ -62,7 +63,8 @@ func Fire(p TriggerParameters) (string, error) {
 		Cost:         p.Cost,
 		Status:       p.Status,
 		ItemID:       p.ItemID,
-		StreamTitle:  p.StreamTitle,
+		Description:  p.Description,
+		ItemName:     p.ItemName,
 	}
 
 	e, err := types.GetByTriggerAndTransport(p.Event, p.Transport)

--- a/internal/events/types/channel_points_redemption/redemption_event.go
+++ b/internal/events/types/channel_points_redemption/redemption_event.go
@@ -45,6 +45,10 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 		params.Cost = 150
 	}
 
+	if params.ItemName == "" {
+		params.ItemName = "Test Reward from CLI"
+	}
+
 	switch params.Transport {
 	case models.TransportEventSub:
 		body := *&models.RedemptionEventSubResponse{
@@ -75,7 +79,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				Status:               params.Status,
 				Reward: models.RedemptionReward{
 					ID:     params.ItemID,
-					Title:  "Test Reward from CLI",
+					Title:  params.ItemName,
 					Cost:   params.Cost,
 					Prompt: "Redeem Your Test Reward from CLI",
 				},

--- a/internal/events/types/channel_points_redemption/redemption_event_test.go
+++ b/internal/events/types/channel_points_redemption/redemption_event_test.go
@@ -25,6 +25,7 @@ func TestEventSub(t *testing.T) {
 		Status:     "tested",
 		ItemID:     "12345678-1234-abcd-5678-000000000000",
 		Cost:       1337,
+		ItemName:   "Testing",
 	}
 
 	r, err := Event{}.GenerateEvent(params)
@@ -39,6 +40,7 @@ func TestEventSub(t *testing.T) {
 	a.Equal(params.Status, body.Event.Status)
 	a.Equal(params.Cost, body.Event.Reward.Cost)
 	a.Equal(params.ItemID, body.Event.Reward.ID)
+	a.Equal(params.ItemName, body.Event.Reward.Title)
 
 	params = events.MockEventParameters{
 		Transport:  models.TransportEventSub,

--- a/internal/events/types/channel_points_reward/reward_event.go
+++ b/internal/events/types/channel_points_reward/reward_event.go
@@ -38,6 +38,10 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 		params.Cost = 150
 	}
 
+	if params.ItemName == "" {
+		params.ItemName = "Test Reward from CLI"
+	}
+
 	switch params.Transport {
 	case models.TransportEventSub:
 		body := models.EventsubResponse{
@@ -64,7 +68,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				IsEnabled:                         true,
 				IsPaused:                          false,
 				IsInStock:                         true,
-				Title:                             "Test Reward from CLI",
+				Title:                             params.ItemName,
 				Cost:                              params.Cost,
 				Prompt:                            "Redeem Your Test Reward from CLI",
 				IsUserInputRequired:               true,

--- a/internal/events/types/channel_points_reward/reward_event_test.go
+++ b/internal/events/types/channel_points_reward/reward_event_test.go
@@ -25,6 +25,7 @@ func TestEventSub(t *testing.T) {
 		Status:     "tested",
 		ItemID:     "12345678-1234-abcd-5678-000000000000",
 		Cost:       1337,
+		ItemName:   "Testing",
 	}
 
 	r, err := Event{}.GenerateEvent(params)
@@ -36,6 +37,7 @@ func TestEventSub(t *testing.T) {
 
 	a.Equal(toUser, body.Event.BroadcasterUserID, "Expected to user %v, got %v", toUser, body.Event.BroadcasterUserID)
 	a.Equal(params.Cost, body.Event.Cost, "Expected cost %v, got %v", params.Cost, body.Event.Cost)
+	a.Equal(params.ItemName, body.Event.Title)
 }
 
 func TestWebSub(t *testing.T) {

--- a/internal/events/types/stream_change/stream_change_event.go
+++ b/internal/events/types/stream_change/stream_change_event.go
@@ -21,10 +21,10 @@ var triggerSupported = []string{"stream-change"}
 
 var triggerMapping = map[string]map[string]string{
 	models.TransportWebSub: {
-		"stream_change": "streams",
+		"stream-change": "streams",
 	},
 	models.TransportEventSub: {
-		"stream_change": "channel.update",
+		"stream-change": "channel.update",
 	},
 }
 
@@ -34,8 +34,14 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	var event []byte
 	var err error
 
-	if params.StreamTitle == "" {
-		params.StreamTitle = "Example title from the CLI!"
+	if params.Description == "" {
+		params.Description = "Example title from the CLI!"
+	}
+	if params.ItemID == "" {
+		params.ItemID = "509658"
+	}
+	if params.ItemName == "" {
+		params.ItemName = "Just Chatting"
 	}
 
 	switch params.Transport {
@@ -61,11 +67,11 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				BroadcasterUserID:    params.ToUserID,
 				BroadcasterUserLogin: params.ToUserName,
 				BroadcasterUserName:  params.ToUserName,
-				StreamTitle:          params.StreamTitle,
+				StreamTitle:          params.Description,
 				StreamLanguage:       "en",
-				StreamCategoryID:     "509658",
-				StreamCategoryName:   "Just Chatting",
-				IsMature:             "true",
+				StreamCategoryID:     params.ItemID,
+				StreamCategoryName:   params.ItemName,
+				IsMature:             false,
 			},
 		}
 		event, err = json.Marshal(body)
@@ -80,10 +86,10 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 					BroadcasterUserID:    params.ToUserID,
 					BroadcasterUserLogin: params.ToUserName,
 					BroadcasterUserName:  params.ToUserName,
-					StreamCategoryID:     "509658",
+					StreamCategoryID:     params.ItemID,
 					StreamCategoryName:   "Just Chatting",
 					StreamType:           "live",
-					StreamTitle:          params.StreamTitle,
+					StreamTitle:          params.Description,
 					StreamViewerCount:    9848,
 					StreamStartedAt:      util.GetTimestamp().Format(time.RFC3339),
 					StreamLanguage:       "en",

--- a/internal/events/types/stream_change/stream_change_event_test.go
+++ b/internal/events/types/stream_change/stream_change_event_test.go
@@ -40,6 +40,7 @@ func TestEventSub(t *testing.T) {
 		ToUserID:   toUser,
 		Transport:  models.TransportEventSub,
 		Trigger:    "stream_change",
+		ItemID:     "1234",
 	}
 
 	r, err = Event{}.GenerateEvent(params)
@@ -50,6 +51,7 @@ func TestEventSub(t *testing.T) {
 
 	a.Equal(toUser, body.Event.BroadcasterUserID, "Expected Stream Channel %v, got %v", toUser, body.Event.BroadcasterUserID)
 	a.Equal("Example title from the CLI!", body.Event.StreamTitle, "Expected new stream title, got %v", body.Event.StreamTitle)
+	a.Equal("1234", body.Event.StreamCategoryID)
 }
 
 func TestWebSubStreamChange(t *testing.T) {
@@ -57,12 +59,13 @@ func TestWebSubStreamChange(t *testing.T) {
 
 	newStreamTitle := "Awesome new title from the CLI!"
 
-	params := *&events.MockEventParameters{
+	params := events.MockEventParameters{
 		FromUserID:  fromUser,
 		ToUserID:    toUser,
 		Transport:   models.TransportWebSub,
 		Trigger:     "stream-change",
-		StreamTitle: newStreamTitle,
+		Description: newStreamTitle,
+		ItemID:      "1234",
 	}
 
 	r, err := Event{}.GenerateEvent(params)
@@ -75,11 +78,12 @@ func TestWebSubStreamChange(t *testing.T) {
 	// write tests here for websub
 	a.Equal(toUser, body.Data[0].BroadcasterUserID, "Expected Stream Channel %v, got %v", toUser, body.Data[0].BroadcasterUserID)
 	a.Equal(newStreamTitle, body.Data[0].StreamTitle, "Expected new stream title, got %v", body.Data[0].StreamTitle)
+	a.Equal("1234", body.Data[0].StreamCategoryID)
 }
 func TestFakeTransport(t *testing.T) {
 	a := util.SetupTestEnv(t)
 
-	params := *&events.MockEventParameters{
+	params := events.MockEventParameters{
 		FromUserID: fromUser,
 		ToUserID:   toUser,
 		Transport:  "fake_transport",

--- a/internal/events/types/streamup/streamup.go
+++ b/internal/events/types/streamup/streamup.go
@@ -33,8 +33,12 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	var event []byte
 	var err error
 
-	if params.StreamTitle == "" {
-		params.StreamTitle = "Example title from the CLI!"
+	if params.Description == "" {
+		params.Description = "Example title from the CLI!"
+	}
+
+	if params.ItemID == "" {
+		params.ItemID = "509658"
 	}
 
 	switch params.Transport {
@@ -76,9 +80,9 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 					UserID:       params.ToUserID,
 					UserLogin:    params.ToUserName,
 					UserName:     params.ToUserName,
-					GameID:       "509658",
+					GameID:       params.ItemID,
 					Type:         "live",
-					Title:        params.StreamTitle,
+					Title:        params.Description,
 					ViewerCount:  util.RandomViewerCount(),
 					StartedAt:    util.GetTimestamp().Format(time.RFC3339),
 					Language:     "en",

--- a/internal/models/stream_change.go
+++ b/internal/models/stream_change.go
@@ -10,7 +10,7 @@ type ChannelUpdateEventSubEvent struct {
 	StreamLanguage       string `json:"language"`
 	StreamCategoryID     string `json:"category_id"`
 	StreamCategoryName   string `json:"category_name"`
-	IsMature             string `json:"is_mature"`
+	IsMature             bool   `json:"is_mature"`
 }
 
 type StreamChangeWebSubResponse struct {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Adds a new `item-name` flag to support #60 as well as adding this support to the CoPo topics. 

## Description of Changes: 

- Adds `item-name`/`n` as a flag for item name support (game name/copo title)
- Updated tests to check
- FIxed some small issues with the `stream-chjange` topic

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
