### PR TITLE
build static binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
       -
         name: Build with xgo
         uses: crazy-max/ghaction-xgo@v1
+        env:
+          CGO_ENABLED: "0"
         with:
           dest: build
           targets: windows/amd64,linux/amd64,darwin/amd64

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Build with xgo
         uses: crazy-max/ghaction-xgo@v1
+        env:
+          CGO_ENABLED: "0"
         with:
           dest: build
           targets: windows/amd64,linux/amd64,darwin/amd64

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test-release:
 		twitch-cli:latest --rm-dist --skip-publish --snapshot
 	
 build:
-	go build --ldflags "-X main.buildVersion=source"
+	CGO_ENABLED=0 go build --ldflags "-X main.buildVersion=source"
 
 build_all:
-	xgo -out build/twitch --targets "darwin/amd64,windows/amd64,linux/amd64" --ldflags "-X main.buildVersion=source" ./
+	CGO_ENABLED=0 xgo -out build/twitch --targets "darwin/amd64,windows/amd64,linux/amd64" --ldflags "-X main.buildVersion=source" ./


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

The current release `1.0.2` is not working in alpine (musl) based environment:

Original Error:
~ # twitch
sh: twitch: not found

Investigation:
~ # ldd /usr/local/bin/twitch
 /lib64/ld-linux-x86-64.so.2 (0x7f04f7e02000)
 libdl.so.2 => /lib64/ld-linux-x86-64.so.2 (0x7f04f7e02000)
 libpthread.so.0 => /lib64/ld-linux-x86-64.so.2 (0x7f04f7e02000)
 libc.so.6 => /lib64/ld-linux-x86-64.so.2 (0x7f04f7e02000)
Error relocating /usr/local/bin/twitch: __memcpy_chk: symbol not found
Error relocating /usr/local/bin/twitch: __memset_chk: symbol not found

My current workaround is to build the cli from source as shown here: https://github.com/cidverse/image-twitchcli/blob/main/Dockerfile

## Description of Changes: 

It would be nice if the binaries could be statically linked to make them more portable.
I hope that this covers all the places that are relevant.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [ ] I have made comments on pieces of code that may be difficult to understand for other editors
- [ ] I have updated the documentation (if applicable)
