### PR TITLE
Fix panic while accessing nil pagination

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -110,7 +110,9 @@ func NewRequest(method string, path string, queryParameters []string, body []byt
 		}
 
 		if autopaginate == false {
-			data.Pagination.Cursor = apiResponse.Pagination.Cursor
+			data.Pagination = &models.APIPagination{
+				Cursor: apiResponse.Pagination.Cursor,
+			}
 			break
 		}
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Calling API endpoints with pagination would result in a panic.
It occurs, because `data.Pagination` was `nil` while we were trying to assign a string to its property `Cursor`, which is illegal. This has been introduced in commit 5e032a25.

## Description of Changes: 

In the Pull Request instead of assigning a string to `Cursor` I set `data.Pagination`, so it won't be `nil` anymore.
Example of a call that'd result in a panic: `twitch api get streams`

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
