### PR TITLE
Adding support for transaction events with eventsub transport.

### DIFF
--- a/internal/events/trigger/trigger_event_test.go
+++ b/internal/events/trigger/trigger_event_test.go
@@ -172,7 +172,8 @@ func TestFire(t *testing.T) {
 		Count:          0,
 	}
 	res, err = Fire(params)
-	a.NotNil(err)
+	a.Nil(err)
+	a.NotEmpty(res)
 
 	params = *&TriggerParameters{
 		Event:          "add-reward",

--- a/internal/models/eventsub.go
+++ b/internal/models/eventsub.go
@@ -23,6 +23,7 @@ type EventsubCondition struct {
 	ToBroadcasterUserID   string `json:"to_broadcaster_user_id,omitempty"`
 	FromBroadcasterUserID string `json:"from_broadcaster_user_id,omitempty"`
 	ClientID              string `json:"client_id,omitempty"`
+	ExtensionClientID     string `json:"extension_client_id,omitempty"`
 }
 
 type EventsubResponse struct {

--- a/internal/models/transactions.go
+++ b/internal/models/transactions.go
@@ -2,6 +2,30 @@
 // SPDX-License-Identifier: Apache-2.0
 package models
 
+type TransactionEventSubEvent struct {
+	ID                   string                     `json:"id"`
+	ExtensionClientID    string                     `json:"extension_client_id"`
+	BroadcasterUserID    string                     `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string                     `json:"broadcaster_user_login"`
+	BroadcasterUserName  string                     `json:"broadcaster_user_name"`
+	UserName             string                     `json:"user_name"`
+	UserLogin            string                     `json:"user_login"`
+	UserID               string                     `json:"user_id"`
+	Product              TransactionEventSubProduct `json:"product"`
+}
+
+type TransactionEventSubProduct struct {
+	Name          string `json:"name"`
+	Sku           string `json:"sku"`
+	Bits          int64  `json:"bits"`
+	InDevelopment bool   `json:"in_development"`
+}
+
+type TransactionEventSubResponse struct {
+	Subscription EventsubSubscription     `json:"subscription"`
+	Event        TransactionEventSubEvent `json:"event"`
+}
+
 type TransactionWebsubEvent struct {
 	ID              string             `json:"id"`
 	Timestamp       string             `json:"timestamp"`


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Allow using `transaction` event with `eventsub` transport.

## Description of Changes: 

- Added `ExtensionClientID` to `EventsubCondition`
- Added `TransactionEventSub` models
- `transaction` event will use the `CLIENTID` from configuration file if present, otherwise will randomize value.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
