### PR TITLE
Fixed a crash upon trying to use query param with no value

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -56,9 +56,13 @@ func NewRequest(method string, path string, queryParameters []string, body []byt
 		}
 
 		q := u.Query()
-		for _, param := range queryParameters {
-			value := strings.Split(param, "=")
-			q.Add(value[0], value[1])
+		for _, paramStr := range queryParameters {
+			var value string
+			param := strings.Split(paramStr, "=")
+			if len(param) == 2 {
+				value = param[1]
+			}
+			q.Add(param[0], value)
 		}
 
 		if cursor != "" {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Fixes a crash upon trying to execute an API request with query parameters that have no value (value of `-q` flag doesn't contain "=").
To reproduce, run an example command: `twitch api get streams -q user_login`

## Description of Changes: 

Changed names of some variables to make it more clear what is what and made added a vairable with empty string as a fallback in case query param's value isn't specified.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
