### PR TITLE
Fix for incorrect Hypetrain EventSub data

### DIFF
--- a/internal/events/types/hype_train/hype_train_event.go
+++ b/internal/events/types/hype_train/hype_train_event.go
@@ -39,7 +39,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	lastType := util.RandomType()
 
 	//Local variables which will be used for the trigger params below
-	localLevel := util.RandomInt(5)
+	localLevel := util.RandomInt(4) + 1
 	localTotal := util.RandomInt(10 * 100)
 	localGoal := util.RandomInt(10*100*100) + localTotal
 	localProgress := (localTotal / localGoal)

--- a/internal/events/types/hype_train/hype_train_event.go
+++ b/internal/events/types/hype_train/hype_train_event.go
@@ -39,6 +39,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	lastType := util.RandomType()
 
 	//Local variables which will be used for the trigger params below
+	localLevel := util.RandomInt(5)
 	localTotal := util.RandomInt(10 * 100)
 	localGoal := util.RandomInt(10*100*100) + localTotal
 	localProgress := (localTotal / localGoal)
@@ -92,11 +93,20 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 					UserLoginWhoMadeContribution: "cli_user2",
 				},
 				StartedAtTimestamp: util.GetTimestamp().Format(time.RFC3339Nano),
-				ExpiresAtTimestamp: util.GetTimestamp().Format(time.RFC3339Nano),
+				ExpiresAtTimestamp: util.GetTimestamp().Add(5 * time.Minute).Format(time.RFC3339Nano),
 			},
 		}
-		if triggerMapping[params.Transport][params.Trigger] == "hype-train-end " {
+		if triggerMapping[params.Transport][params.Trigger] == "channel.hype_train.progress" {
+			body.Event.Level = localLevel
+		}
+		if triggerMapping[params.Transport][params.Trigger] == "channel.hype_train.end" {
 			body.Event.CooldownEndsAtTimestamp = util.GetTimestamp().Add(1 * time.Hour).Format(time.RFC3339Nano)
+			body.Event.EndedAtTimestamp = util.GetTimestamp().Format(time.RFC3339Nano)
+			body.Event.ExpiresAtTimestamp = ""
+			body.Event.Goal = 0
+			body.Event.Level = localLevel
+			body.Event.Progress = 0
+			body.Event.StartedAtTimestamp = util.GetTimestamp().Add(5 * -time.Minute).Format(time.RFC3339Nano)
 		}
 		event, err = json.Marshal(body)
 		if err != nil {

--- a/internal/events/types/hype_train/hype_train_event.go
+++ b/internal/events/types/hype_train/hype_train_event.go
@@ -96,10 +96,10 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ExpiresAtTimestamp: util.GetTimestamp().Add(5 * time.Minute).Format(time.RFC3339Nano),
 			},
 		}
-		if triggerMapping[params.Transport][params.Trigger] == "channel.hype_train.progress" {
+		if params.Trigger == "hype-train-progress" {
 			body.Event.Level = localLevel
 		}
-		if triggerMapping[params.Transport][params.Trigger] == "channel.hype_train.end" {
+		if params.Trigger == "hype-train-end" {
 			body.Event.CooldownEndsAtTimestamp = util.GetTimestamp().Add(1 * time.Hour).Format(time.RFC3339Nano)
 			body.Event.EndedAtTimestamp = util.GetTimestamp().Format(time.RFC3339Nano)
 			body.Event.ExpiresAtTimestamp = ""


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

hype-train-progress and hype-train-end events were generating data that did not match the API docs.

## Description of Changes: 

- Set `expires_at` to be 5 minutes after `started_at`
- **hype-train-progress**
  - Added missing `level` event value
- **hype-train-end**
  - Condition was incorrect and not being triggered
  - Added missing `expired_at` and `level` event values
  - Set `started_at` to be 5 minutes before `expired_at`
  - Unset `goal`, `progress`, and `expires_at` values

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [ ] I have made comments on pieces of code that may be difficult to understand for other editors
- [ ] I have updated the documentation (if applicable)
