### PR TITLE
updating eventsub to match production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ twitch-cli
 *.html
 
 # Editor configs
-.vsvode/
+.vscode/
 .idea/
 
 # junk files

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "cSpell.words": [
-        "SPDX"
-    ]
-}

--- a/cmd/events.go
+++ b/cmd/events.go
@@ -28,6 +28,7 @@ var (
 	cost           int64
 	count          int
 	description    string
+	gameID         string
 )
 
 var eventCmd = &cobra.Command{
@@ -90,6 +91,7 @@ func init() {
 	triggerCmd.Flags().StringVarP(&itemName, "item-name", "n", "", "Manually set the name of the event payload item (for example the reward ID in redemption events). For stream events, this is the game title.")
 	triggerCmd.Flags().Int64VarP(&cost, "cost", "C", 0, "Amount of bits or channel points redeemed/used in the event.")
 	triggerCmd.Flags().StringVarP(&description, "description", "d", "", "Title the stream should be updated with.")
+	triggerCmd.Flags().StringVarP(&gameID, "game-id", "G", "", "Sets the game/category ID for applicable events.")
 
 	// retrigger flags
 	retriggerCmd.Flags().StringVarP(&forwardAddress, "forward-address", "F", "", "Forward address for mock event.")
@@ -134,6 +136,7 @@ func triggerCmdRun(cmd *cobra.Command, args []string) {
 			Cost:           cost,
 			Description:    description,
 			ItemName:       itemName,
+			GameID:         gameID,
 		})
 
 		if err != nil {

--- a/docs/event.md
+++ b/docs/event.md
@@ -16,30 +16,42 @@ Used to either create or send mock events for use with local webhooks testing.
 
 **Args**
 
-| Argument              | Description                                                                                                |
-|-----------------------|------------------------------------------------------------------------------------------------------------|
-| `subscribe`           | A standard subscription event. Triggers a basic tier 1 sub.                                                |
-| `unsubscribe`         | A standard unsubscribe event. Triggers a basic tier 1 sub.                                                 |
-| `gift`                | A gifted subscription event. Triggers a basic tier 1 sub.                                                  |
-| `cheer`               | Only usable with the `eventsub` transport, shows Cheers from chat.                                         |
-| `transaction`         | Bits in Extensions transactions events.                                                                    |
-| `add-reward`          | Channel Points EventSub event for a Custom Reward being added.                                             |
-| `update-reward`       | Channel Points EventSub event for a Custom Reward being updated.                                           |
-| `remove-reward`       | Channel Points EventSub event for a Custom Reward being removed.                                           |
-| `add-redemption`      | Channel Points EventSub event for a redemption being performed.                                            |
-| `update-redemption`   | Channel Points EventSub event for a redemption being updated.                                              |
-| `raid`                | Channel Raid event with a random viewer count.                                                             |
-| `revoke`              | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly. |
-| `stream-change`       | Stream Changed event.                                                                                      |
-| `streamup`            | Stream online event.                                                                                       |
-| `streamdown`          | Sstream offline event.                                                                                     |
-| `add-moderator`       | Channel moderator add event.                                                                               |
-| `remove-moderator`    | Channel moderator removal event.                                                                           |
-| `ban`                 | Channel ban event.                                                                                         |
-| `unban`               | Channel unban event.                                                                                       |
-| `hype-train-begin`    | Channel hype train start event.                                                                            |
-| `hype-train-progress` | Channel hype train progress event.                                                                         |
-| `hype-train-end`      | Channel hype train end event.                                                                              |
+| Argument              | Description                                                                                                                          |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `add-moderator`       | Channel moderator add event.                                                                                                         |
+| `add-redemption`      | Channel Points EventSub event for a redemption being performed.                                                                      |
+| `add-reward`          | Channel Points EventSub event for a Custom Reward being added.                                                                       |
+| `ban`                 | Channel ban event.                                                                                                                   |
+| `channel-gift`        | Channel gifting event; not to be confused with the `gift` event. This event is a description of the number of gifts given by a user. |
+| `cheer`               | Only usable with the `eventsub` transport                                                                                            |
+| `drop`                | Drops Entitlement event.                                                                                                             |
+| `gift`                | A gifted subscription event. Triggers a basic tier 1 sub.                                                                            |
+| `grant`               | Authorization grant event.                                                                                                           |
+| `hype-train-begin`    | Channel hype train start event.                                                                                                      |
+| `hype-train-end`      | Channel hype train end event.                                                                                                        |
+| `hype-train-progress` | Channel hype train progress event.                                                                                                   |
+| `poll-begin`          | Channel poll begin event.                                                                                                            |
+| `poll-end`            | Channel poll end event.                                                                                                              |
+| `poll-progress`       | Channel poll progress event.                                                                                                         |
+| `prediction-begin`    | Channel prediction begin event.                                                                                                      |
+| `prediction-end`      | Channel prediction end event.                                                                                                        |
+| `prediction-lock`     | Channel prediction lock event.                                                                                                       |
+| `prediction-progress` | Channel prediction progress event.                                                                                                   |
+| `raid`                | Channel Raid event with a random viewer count.                                                                                       |
+| `remove-moderator`    | Channel moderator removal event.                                                                                                     |
+| `remove-reward`       | Channel Points EventSub event for a Custom Reward being removed.                                                                     |
+| `revoke`              | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly.                           |
+| `stream-change`       | Stream Changed event.                                                                                                                |
+| `streamdown`          | Sstream offline event.                                                                                                               |
+| `streamup`            | Stream online event.                                                                                                                 |
+| `subscribe-message`   | Subscription Message event.                                                                                                          |
+| `subscribe`           | A standard subscription event. Triggers a basic tier 1 sub.                                                                          |
+| `transaction`         | Bits in Extensions transactions events.                                                                                              |
+| `unban`               | Channel unban event.                                                                                                                 |
+| `unsubscribe`         | A standard unsubscribe event. Triggers a basic tier 1 sub.                                                                           |
+| `update-redemption`   | Channel Points EventSub event for a redemption being updated.                                                                        |
+| `update-reward`       | Channel Points EventSub event for a Custom Reward being updated.                                                                     |
+
 
 
 
@@ -48,18 +60,18 @@ Used to either create or send mock events for use with local webhooks testing.
 | Flag                | Shorthand | Description                                                                                                                     | Example                                   | Required? (Y/N) |
 |---------------------|-----------|---------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|-----------------|
 | `--forward-address` | `-F`      | Web server address for where to send mock events.                                                                               | `-F https://localhost:8080`               | N               |
-| `--transport`       | `-T`      | The method used to send events. Default is eventsub, but can send using websub.                                                 | `-T websub`                               | N               |
+| `--transport`       | `-T`      | The method used to send events. Default is `eventsub`, but can send using `websub`.                                             | `-T websub`                               | N               |
 | `--to-user`         | `-t`      | Denotes the receiver's TUID of the event, usually the broadcaster.                                                              | `-t 44635596`                             | N               |
 | `--from-user`       | `-f`      | Denotes the sender's TUID of the event, for example the user that follows another user or the subscriber to a broadcaster.      | `-f 44635596`                             | N               |
 | `--gift-user`       | `-g`      | Used only for subcription-based events, denotes the gifting user ID                                                             | `-g 44635596`                             | N               |
 | `--secret`          | `-s`      | Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC.                                                    | `-s testsecret`                           | N               |
-| `--count`           | `-c`      | Count of events to fire. This can be used to simulate an influx of subscriptions.                                               | `-c 100`                                  | N               |
+| `--count`           | `-c`      | Count of events to fire. This can be used to simulate an influx of events.                                                      | `-c 100`                                  | N               |
 | `--anonymous`       | `-a`      | If the event is anonymous. Only applies to `gift` and `cheer` events.                                                           | `-a`                                      | N               |
 | `--status`          | `-S`      | Status of the event object, currently applies to channel points redemptions.                                                    | `-S fulfilled`                            | N               |
 | `--item-id`         | `-i`      | Manually set the ID of the event payload item (for example the reward ID in redemption events or game in stream events).        | `-i 032e4a6c-4aef-11eb-a9f5-1f703d1f0b92` | N               |
 | `--item-name`       | `-n`      | Manually set the name of the event payload item (for example the reward ID in redemption events or game name in stream events). | `-n "Science & Technology"`               | N               |
 | `--cost`            | `-C`      | Amount of bits or channel points redeemed/used in the event.                                                                    | `-C 250`                                  | N               |
-| `--description`     | `-d`      | Title the stream should be updated/started with.                                                                                | `-d Awesome new title!`                   | N               |
+| `--description`     | `-d`      | Title the stream should be updated/started with. Additionally used as the category ID for Drops events.                         | `-d Awesome new title!`                   | N               |
 
 
 **Examples**
@@ -110,30 +122,42 @@ Allows you to test if your webserver responds to subscription requests properly.
 
 **Args**
 
-| Argument              | Description                                                                                                |
-|-----------------------|------------------------------------------------------------------------------------------------------------|
-| `subscribe`           | A standard subscription event. Triggers a basic tier 1 sub.                                                |
-| `unsubscribe`         | A standard unsubscribe event. Triggers a basic tier 1 sub.                                                 |
-| `gift`                | A gifted subscription event. Triggers a basic tier 1 sub.                                                  |
-| `cheer`               | Only usable with the `eventsub` transport, shows Cheers from chat.                                         |
-| `transaction`         | Bits in Extensions transactions events.                                                                    |
-| `add-reward`          | Channel Points EventSub event for a Custom Reward being added.                                             |
-| `update-reward`       | Channel Points EventSub event for a Custom Reward being updated.                                           |
-| `remove-reward`       | Channel Points EventSub event for a Custom Reward being removed.                                           |
-| `add-redemption`      | Channel Points EventSub event for a redemption being performed.                                            |
-| `update-redemption`   | Channel Points EventSub event for a redemption being updated.                                              |
-| `raid`                | Channel Raid event with a random viewer count.                                                             |
-| `revoke`              | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly. |
-| `stream-change`       | Stream Changed event.                                                                                      |
-| `streamup`            | Stream online event.                                                                                       |
-| `streamdown`          | Sstream offline event.                                                                                     |
-| `add-moderator`       | Channel moderator add event.                                                                               |
-| `remove-moderator`    | Channel moderator removal event.                                                                           |
-| `ban`                 | Channel ban event.                                                                                         |
-| `unban`               | Channel unban event.                                                                                       |
-| `hype-train-begin`    | Channel hype train start event.                                                                            |
-| `hype-train-progress` | Channel hype train progress event.                                                                         |
-| `hype-train-end`      | Channel hype train end event.                                                                              |
+| Argument              | Description                                                                                                                          |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `add-moderator`       | Channel moderator add event.                                                                                                         |
+| `add-redemption`      | Channel Points EventSub event for a redemption being performed.                                                                      |
+| `add-reward`          | Channel Points EventSub event for a Custom Reward being added.                                                                       |
+| `ban`                 | Channel ban event.                                                                                                                   |
+| `channel-gift`        | Channel gifting event; not to be confused with the `gift` event. This event is a description of the number of gifts given by a user. |
+| `cheer`               | Only usable with the `eventsub` transport                                                                                            |
+| `drop`                | Drops Entitlement event.                                                                                                             |
+| `gift`                | A gifted subscription event. Triggers a basic tier 1 sub.                                                                            |
+| `grant`               | Authorization grant event.                                                                                                           |
+| `hype-train-begin`    | Channel hype train start event.                                                                                                      |
+| `hype-train-end`      | Channel hype train end event.                                                                                                        |
+| `hype-train-progress` | Channel hype train progress event.                                                                                                   |
+| `poll-begin`          | Channel poll begin event.                                                                                                            |
+| `poll-end`            | Channel poll end event.                                                                                                              |
+| `poll-progress`       | Channel poll progress event.                                                                                                         |
+| `prediction-begin`    | Channel prediction begin event.                                                                                                      |
+| `prediction-end`      | Channel prediction end event.                                                                                                        |
+| `prediction-lock`     | Channel prediction lock event.                                                                                                       |
+| `prediction-progress` | Channel prediction progress event.                                                                                                   |
+| `raid`                | Channel Raid event with a random viewer count.                                                                                       |
+| `remove-moderator`    | Channel moderator removal event.                                                                                                     |
+| `remove-reward`       | Channel Points EventSub event for a Custom Reward being removed.                                                                     |
+| `revoke`              | User authorization revoke event. Uses local Client as set in `twitch configure` or generates one randomly.                           |
+| `stream-change`       | Stream Changed event.                                                                                                                |
+| `streamdown`          | Sstream offline event.                                                                                                               |
+| `streamup`            | Stream online event.                                                                                                                 |
+| `subscribe-message`   | Subscription Message event.                                                                                                          |
+| `subscribe`           | A standard subscription event. Triggers a basic tier 1 sub.                                                                          |
+| `transaction`         | Bits in Extensions transactions events.                                                                                              |
+| `unban`               | Channel unban event.                                                                                                                 |
+| `unsubscribe`         | A standard unsubscribe event. Triggers a basic tier 1 sub.                                                                           |
+| `update-redemption`   | Channel Points EventSub event for a redemption being updated.                                                                        |
+| `update-reward`       | Channel Points EventSub event for a Custom Reward being updated.                                                                     |
+
 
 **Flags**
 

--- a/docs/event.md
+++ b/docs/event.md
@@ -57,21 +57,23 @@ Used to either create or send mock events for use with local webhooks testing.
 
 **Flags**
 
-| Flag                | Shorthand | Description                                                                                                                     | Example                                   | Required? (Y/N) |
-|---------------------|-----------|---------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|-----------------|
-| `--forward-address` | `-F`      | Web server address for where to send mock events.                                                                               | `-F https://localhost:8080`               | N               |
-| `--transport`       | `-T`      | The method used to send events. Default is `eventsub`, but can send using `websub`.                                             | `-T websub`                               | N               |
-| `--to-user`         | `-t`      | Denotes the receiver's TUID of the event, usually the broadcaster.                                                              | `-t 44635596`                             | N               |
-| `--from-user`       | `-f`      | Denotes the sender's TUID of the event, for example the user that follows another user or the subscriber to a broadcaster.      | `-f 44635596`                             | N               |
-| `--gift-user`       | `-g`      | Used only for subcription-based events, denotes the gifting user ID                                                             | `-g 44635596`                             | N               |
-| `--secret`          | `-s`      | Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC.                                                    | `-s testsecret`                           | N               |
-| `--count`           | `-c`      | Count of events to fire. This can be used to simulate an influx of events.                                                      | `-c 100`                                  | N               |
-| `--anonymous`       | `-a`      | If the event is anonymous. Only applies to `gift` and `cheer` events.                                                           | `-a`                                      | N               |
-| `--status`          | `-S`      | Status of the event object, currently applies to channel points redemptions.                                                    | `-S fulfilled`                            | N               |
-| `--item-id`         | `-i`      | Manually set the ID of the event payload item (for example the reward ID in redemption events or game in stream events).        | `-i 032e4a6c-4aef-11eb-a9f5-1f703d1f0b92` | N               |
-| `--item-name`       | `-n`      | Manually set the name of the event payload item (for example the reward ID in redemption events or game name in stream events). | `-n "Science & Technology"`               | N               |
-| `--cost`            | `-C`      | Amount of bits or channel points redeemed/used in the event.                                                                    | `-C 250`                                  | N               |
-| `--description`     | `-d`      | Title the stream should be updated/started with. Additionally used as the category ID for Drops events.                         | `-d Awesome new title!`                   | N               |
+ Flag                | Shorthand | Description                                                                                                                     | Example                                   | Required? (Y/N) 
+---------------------|-----------|---------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|-----------------
+ `--forward-address` | `-F`      | Web server address for where to send mock events.                                                                               | `-F https://localhost:8080`               | N               
+ `--transport`       | `-T`      | The method used to send events. Default is `eventsub`, but can send using `websub`.                                             | `-T websub`                               | N               
+ `--to-user`         | `-t`      | Denotes the receiver's TUID of the event, usually the broadcaster.                                                              | `-t 44635596`                             | N               
+ `--from-user`       | `-f`      | Denotes the sender's TUID of the event, for example the user that follows another user or the subscriber to a broadcaster.      | `-f 44635596`                             | N               
+ `--gift-user`       | `-g`      | Used only for subcription-based events, denotes the gifting user ID                                                             | `-g 44635596`                             | N               
+ `--secret`          | `-s`      | Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC.                                                    | `-s testsecret`                           | N               
+ `--count`           | `-c`      | Count of events to fire. This can be used to simulate an influx of events.                                                      | `-c 100`                                  | N               
+ `--anonymous`       | `-a`      | If the event is anonymous. Only applies to `gift` and `cheer` events.                                                           | `-a`                                      | N               
+ `--status`          | `-S`      | Status of the event object, currently applies to channel points redemptions.                                                    | `-S fulfilled`                            | N               
+ `--item-id`         | `-i`      | Manually set the ID of the event payload item (for example the reward ID in redemption events or game in stream events).        | `-i 032e4a6c-4aef-11eb-a9f5-1f703d1f0b92` | N               
+ `--item-name`       | `-n`      | Manually set the name of the event payload item (for example the reward ID in redemption events or game name in stream events). | `-n "Science & Technology"`               | N               
+ `--cost`            | `-C`      | Amount of bits or channel points redeemed/used in the event.                                                                    | `-C 250`                                  | N               
+ `--description`     | `-d`      | Title the stream should be updated/started with.                                                                                | `-d Awesome new title!`                   | N               
+ `--game-id`         | `-G`      | Game ID for Drop or other relevant events.                                                                                      | `-G 1234`                                 | N               
+
 
 
 **Examples**

--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -20,6 +20,7 @@ type MockEventParameters struct {
 	Cost         int64
 	IsPermanent  bool
 	Description  string
+	GameID       string
 }
 
 type MockEventResponse struct {

--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -30,6 +30,7 @@ type TriggerParameters struct {
 	Count          int
 	Description    string
 	ItemName       string
+	GameID         string
 }
 
 type TriggerResponse struct {
@@ -53,6 +54,9 @@ func Fire(p TriggerParameters) (string, error) {
 		p.FromUser = util.RandomUserID()
 	}
 
+	if p.GameID == "" {
+		p.GameID = fmt.Sprint(util.RandomInt(10 * 1000))
+	}
 	eventParamaters := events.MockEventParameters{
 		ID:           util.RandomGUID(),
 		Trigger:      p.Event,
@@ -67,6 +71,7 @@ func Fire(p TriggerParameters) (string, error) {
 		ItemID:       p.ItemID,
 		Description:  p.Description,
 		ItemName:     p.ItemName,
+		GameID:       p.GameID,
 	}
 
 	e, err := types.GetByTriggerAndTransport(p.Event, p.Transport)

--- a/internal/events/types/authorization/authorization.go
+++ b/internal/events/types/authorization/authorization.go
@@ -1,0 +1,95 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package authorization
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
+)
+
+var transportsSupported = map[string]bool{
+	models.TransportWebSub:   false,
+	models.TransportEventSub: true,
+}
+
+var triggerSupported = []string{"revoke", "grant"}
+
+var triggerMapping = map[string]map[string]string{
+	models.TransportEventSub: {
+		"revoke": "user.authorization.revoke",
+		"grant":  "user.authorization.grant",
+	},
+}
+
+type Event struct{}
+
+func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEventResponse, error) {
+	var event []byte
+	var err error
+	clientID := viper.GetString("ClientID")
+
+	// if not configured, generate a random one
+	if clientID == "" {
+		clientID = util.RandomClientID()
+	}
+	switch params.Transport {
+	case models.TransportEventSub:
+		body := &models.AuthorizationRevokeEventSubResponse{
+			Subscription: models.EventsubSubscription{
+				ID:      params.ID,
+				Status:  "enabled",
+				Type:    triggerMapping[params.Transport][params.Trigger],
+				Version: "1",
+				Condition: models.EventsubCondition{
+					ClientID: clientID,
+				},
+				Transport: models.EventsubTransport{
+					Method:   "webhook",
+					Callback: "null",
+				},
+				Cost:      1,
+				CreatedAt: util.GetTimestamp().Format(time.RFC3339Nano),
+			},
+			Event: models.AuthorizationRevokeEvent{
+				ClientID:  clientID,
+				UserID:    params.FromUserID,
+				UserLogin: params.FromUserName,
+				UserName:  params.FromUserName,
+			},
+		}
+		event, err = json.Marshal(body)
+		if err != nil {
+			return events.MockEventResponse{}, err
+		}
+	default:
+		return events.MockEventResponse{}, nil
+	}
+
+	return events.MockEventResponse{
+		ID:       params.ID,
+		JSON:     event,
+		FromUser: params.FromUserID,
+		ToUser:   params.ToUserID,
+	}, nil
+}
+
+func (e Event) ValidTransport(t string) bool {
+	return transportsSupported[t]
+}
+
+func (e Event) ValidTrigger(t string) bool {
+	for _, ts := range triggerSupported {
+		if ts == t {
+			return true
+		}
+	}
+	return false
+}
+func (e Event) GetTopic(transport string, trigger string) string {
+	return triggerMapping[transport][trigger]
+}

--- a/internal/events/types/authorization/authorization_test.go
+++ b/internal/events/types/authorization/authorization_test.go
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package authorization
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/test_setup"
+)
+
+var fromUser = "1234"
+var toUser = "4567"
+
+func TestEventSub(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	viper.Set("ClientID", "1234")
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportEventSub,
+		Trigger:    "subscribe",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.AuthorizationRevokeEventSubResponse
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	a.NotEmpty(body.Event.ClientID)
+	a.Equal(body.Event.ClientID, body.Subscription.Condition.ClientID)
+	a.Equal("1234", body.Event.ClientID)
+}
+func TestFakeTransport(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  "fake_transport",
+		Trigger:    "unsubscribe",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+	a.Empty(r)
+}
+func TestValidTrigger(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.ValidTrigger("revoke")
+	a.Equal(true, r)
+
+	r = Event{}.ValidTrigger("fake_revoke")
+	a.Equal(false, r)
+}
+
+func TestValidTransport(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.ValidTransport(models.TransportEventSub)
+	a.Equal(true, r)
+
+	r = Event{}.ValidTransport("noteventsub")
+	a.Equal(false, r)
+}
+func TestGetTopic(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.GetTopic(models.TransportEventSub, "revoke")
+	a.NotNil(r)
+}

--- a/internal/events/types/drop/drop.go
+++ b/internal/events/types/drop/drop.go
@@ -61,7 +61,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 					ID: util.RandomGUID(),
 					Data: models.DropsEntitlementEventSubEventData{
 						OrganizationID: params.FromUserID,
-						CategoryID:     params.Description,
+						CategoryID:     params.GameID,
 						CategoryName:   "",
 						CampaignID:     util.RandomGUID(),
 						EntitlementID:  util.RandomGUID(),

--- a/internal/events/types/drop/drop_test.go
+++ b/internal/events/types/drop/drop_test.go
@@ -27,7 +27,7 @@ func TestEventSub(t *testing.T) {
 	r, err := Event{}.GenerateEvent(params)
 	a.Nil(err)
 
-	var body models.DropsEntitlementEventSubResponse // replace with actual value
+	var body models.DropsEntitlementEventSubResponse
 	err = json.Unmarshal(r.JSON, &body)
 	a.Nil(err)
 

--- a/internal/events/types/drop/drop_test.go
+++ b/internal/events/types/drop/drop_test.go
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package drop
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/test_setup"
+)
+
+var fromUser = "1234"
+var toUser = "4567"
+
+func TestEventSub(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportEventSub,
+		Trigger:    "drop",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.DropsEntitlementEventSubResponse // replace with actual value
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	a.Len(body.Events, 1)
+}
+
+func TestFakeTransport(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  "fake_transport",
+		Trigger:    "drop",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+	a.Empty(r)
+}
+func TestValidTrigger(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.ValidTrigger("drop")
+	a.Equal(true, r)
+
+	r = Event{}.ValidTrigger("notdrop")
+	a.Equal(false, r)
+}
+
+func TestValidTransport(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.ValidTransport(models.TransportEventSub)
+	a.Equal(true, r)
+
+	r = Event{}.ValidTransport("noteventsub")
+	a.Equal(false, r)
+}
+func TestGetTopic(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.GetTopic(models.TransportEventSub, "drop")
+	a.NotNil(r)
+}

--- a/internal/events/types/gift/channel_gift_test.go
+++ b/internal/events/types/gift/channel_gift_test.go
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package gift
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/test_setup"
+)
+
+var fromUser = "1234"
+var toUser = "4567"
+
+func TestEventSub(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID:  fromUser,
+		ToUserID:    toUser,
+		Transport:   models.TransportEventSub,
+		Trigger:     "channel-gift",
+		Cost:        0,
+		IsAnonymous: true,
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.GiftEventSubResponse // replace with actual value
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	a.GreaterOrEqual(body.Event.Total, 1)
+	a.Nil(body.Event.CumulativeTotal)
+	a.NotEmpty(body.Event.UserID)
+}
+
+func TestFakeTransport(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  "fake_transport",
+		Trigger:    "unsubscribe",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+	a.Empty(r)
+}
+func TestValidTrigger(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.ValidTrigger("channel-gift")
+	a.Equal(true, r)
+
+	r = Event{}.ValidTrigger("notgift")
+	a.Equal(false, r)
+}
+
+func TestValidTransport(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.ValidTransport(models.TransportEventSub)
+	a.Equal(true, r)
+
+	r = Event{}.ValidTransport("noteventsub")
+	a.Equal(false, r)
+}
+func TestGetTopic(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.GetTopic(models.TransportEventSub, "channel-gift")
+	a.NotNil(r)
+}

--- a/internal/events/types/gift/channel_gift_test.go
+++ b/internal/events/types/gift/channel_gift_test.go
@@ -29,7 +29,7 @@ func TestEventSub(t *testing.T) {
 	r, err := Event{}.GenerateEvent(params)
 	a.Nil(err)
 
-	var body models.GiftEventSubResponse // replace with actual value
+	var body models.GiftEventSubResponse
 	err = json.Unmarshal(r.JSON, &body)
 	a.Nil(err)
 

--- a/internal/events/types/poll/poll.go
+++ b/internal/events/types/poll/poll.go
@@ -1,9 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package subscribe
+package poll
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/twitchdev/twitch-cli/internal/events"
@@ -12,24 +13,17 @@ import (
 )
 
 var transportsSupported = map[string]bool{
-	models.TransportWebSub:   true,
+	models.TransportWebSub:   false,
 	models.TransportEventSub: true,
 }
 
-var triggerSupported = []string{"subscribe", "gift", "unsubscribe", "subscribe-end"}
+var triggerSupported = []string{"poll-begin", "poll-progress", "poll-end"}
 
 var triggerMapping = map[string]map[string]string{
-	models.TransportWebSub: {
-		"subscribe":     "subscriptions.subscribe",
-		"unsubscribe":   "subscriptions.unsubscribe",
-		"gift":          "subscriptions.subscribe",
-		"subscribe-end": "",
-	},
 	models.TransportEventSub: {
-		"subscribe":     "channel.subscribe",
-		"unsubscribe":   "channel.unsubscribe",
-		"gift":          "channel.subscribe",
-		"subscribe-end": "channel.subscription.end",
+		"poll-begin":    "channel.poll.begin",
+		"poll-progress": "channel.poll.progress",
+		"poll-end":      "channel.poll.end",
 	},
 }
 
@@ -38,26 +32,28 @@ type Event struct{}
 func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEventResponse, error) {
 	var event []byte
 	var err error
-	var giftUserID string
-	var giftUserName string
 
-	if params.Trigger == "gift" {
-		params.IsGift = true
-	}
-
-	if params.IsGift == true {
-		giftUserID = util.RandomUserID()
-		giftUserName = "testGifter"
-	}
-
-	if params.IsAnonymous == true {
-		giftUserID = "274598607"
-		giftUserName = "ananonymousgifter"
+	if params.Description == "" {
+		params.Description = "Pineapple on pizza?"
 	}
 
 	switch params.Transport {
 	case models.TransportEventSub:
-		body := *&models.EventsubResponse{
+		choices := []models.PollEventSubEventChoice{}
+		for i := 1; i < 5; i++ {
+			c := models.PollEventSubEventChoice{
+				ID:    util.RandomGUID(),
+				Title: fmt.Sprintf("Yes but choice %v", i),
+			}
+			if params.Trigger != "poll-begin" {
+				c.BitsVotes = intPointer(int(util.RandomInt(10)))
+				c.ChannelPointsVotes = intPointer(int(util.RandomInt(10)))
+				c.Votes = intPointer(*c.BitsVotes + *c.ChannelPointsVotes + int(util.RandomInt(10)))
+			}
+			choices = append(choices, c)
+		}
+
+		body := &models.PollEventSubResponse{
 			Subscription: models.EventsubSubscription{
 				ID:      params.ID,
 				Status:  "enabled",
@@ -73,43 +69,31 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				Cost:      0,
 				CreatedAt: util.GetTimestamp().Format(time.RFC3339Nano),
 			},
-			Event: models.SubEventSubEvent{
-				UserID:               params.FromUserID,
-				UserLogin:            params.FromUserName,
-				UserName:             params.FromUserName,
+			Event: models.PollEventSubEvent{
+				ID:                   util.RandomGUID(),
 				BroadcasterUserID:    params.ToUserID,
 				BroadcasterUserLogin: params.ToUserName,
 				BroadcasterUserName:  params.ToUserName,
-				Tier:                 "1000",
-				IsGift:               params.IsGift,
+				Title:                params.Description,
+				Choices:              choices,
+				BitsVoting: models.PollEventSubEventGoodVoting{
+					IsEnabled:     true,
+					AmountPerVote: 10,
+				},
+				ChannelPointsVoting: models.PollEventSubEventGoodVoting{
+					IsEnabled:     true,
+					AmountPerVote: 500,
+				},
+				StartedAt: util.GetTimestamp().Format(time.RFC3339Nano),
 			},
 		}
 
-		event, err = json.Marshal(body)
-		if err != nil {
-			return events.MockEventResponse{}, err
+		if params.Trigger == "poll-end" {
+			body.Event.EndedAt = util.GetTimestamp().Add(time.Minute * 15).Format(time.RFC3339Nano)
+			body.Event.Status = "completed"
+		} else {
+			body.Event.EndsAt = util.GetTimestamp().Add(time.Minute * 15).Format(time.RFC3339Nano)
 		}
-	case models.TransportWebSub:
-		body := *&models.SubWebSubResponse{
-			Data: []models.SubWebSubResponseData{
-				{
-					ID:             params.ID,
-					EventType:      triggerMapping[params.Transport][params.Trigger],
-					EventTimestamp: util.GetTimestamp().Format(time.RFC3339),
-					Version:        "1.0",
-					EventData: models.SubWebSubEventData{
-						BroadcasterID:   params.ToUserID,
-						BroadcasterName: params.ToUserName,
-						UserID:          params.FromUserID,
-						UserName:        params.FromUserID,
-						Tier:            "1000",
-						PlanName:        "Tier 1 Test Sub",
-						IsGift:          params.IsGift,
-						GifterID:        giftUserID,
-						GifterName:      giftUserName,
-					},
-				},
-			}}
 
 		event, err = json.Marshal(body)
 		if err != nil {
@@ -139,7 +123,10 @@ func (e Event) ValidTrigger(t string) bool {
 	}
 	return false
 }
-
 func (e Event) GetTopic(transport string, trigger string) string {
 	return triggerMapping[transport][trigger]
+}
+
+func intPointer(i int) *int {
+	return &i
 }

--- a/internal/events/types/poll/poll_test.go
+++ b/internal/events/types/poll/poll_test.go
@@ -1,0 +1,107 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package poll
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/test_setup"
+)
+
+var fromUser = "1234"
+var toUser = "4567"
+
+func TestEventSub(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportEventSub,
+		Trigger:    "poll-begin",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.PollEventSubResponse
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+	a.NotEmpty(body.Event.EndsAt)
+	a.Empty(body.Event.EndedAt)
+
+	params = *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportEventSub,
+		Trigger:    "poll-progress",
+	}
+
+	r, err = Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	body = models.PollEventSubResponse{}
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+	a.NotEmpty(body.Event.EndsAt)
+	a.Empty(body.Event.EndedAt)
+
+	params = *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportEventSub,
+		Trigger:    "poll-end",
+	}
+
+	r, err = Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	body = models.PollEventSubResponse{}
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+	a.Empty(body.Event.EndsAt)
+	a.NotEmpty(body.Event.EndedAt)
+}
+
+func TestFakeTransport(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  "fake_transport",
+		Trigger:    "poll-begin",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+	a.Empty(r)
+}
+func TestValidTrigger(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.ValidTrigger("poll-begin")
+	a.Equal(true, r)
+
+	r = Event{}.ValidTrigger("notgift")
+	a.Equal(false, r)
+}
+
+func TestValidTransport(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.ValidTransport(models.TransportEventSub)
+	a.Equal(true, r)
+
+	r = Event{}.ValidTransport("noteventsub")
+	a.Equal(false, r)
+}
+func TestGetTopic(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.GetTopic(models.TransportEventSub, "poll-begin")
+	a.NotNil(r)
+}

--- a/internal/events/types/prediction/prediction.go
+++ b/internal/events/types/prediction/prediction.go
@@ -1,0 +1,153 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package prediction
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
+)
+
+var transportsSupported = map[string]bool{
+	models.TransportWebSub:   false,
+	models.TransportEventSub: true,
+}
+
+var triggerSupported = []string{"prediction-begin", "prediction-progress", "prediction-end"}
+
+var triggerMapping = map[string]map[string]string{
+	models.TransportEventSub: {
+		"prediction-begin":    "channel.prediction.begin",
+		"prediction-progress": "channel.prediction.progress",
+		"prediction-lock":     "channel.prediction.lock",
+		"prediction-end":      "channel.prediction.end",
+	},
+}
+
+type Event struct{}
+
+func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEventResponse, error) {
+	var event []byte
+	var err error
+	if params.Description == "" {
+		params.Description = "Will the developer finish this program?"
+	}
+
+	switch params.Transport {
+	case models.TransportEventSub:
+		var outcomes []models.PredictionEventSubEventOutcomes
+		for i := 0; i < 2; i++ {
+			color := "blue"
+			title := "yes"
+
+			if i == 1 {
+				color = "pink"
+				title = "no"
+			}
+
+			o := models.PredictionEventSubEventOutcomes{
+				ID:    util.RandomGUID(),
+				Title: title,
+				Color: color,
+			}
+
+			if params.Trigger != "prediction-begin" {
+				tp := []models.PredictionEventSubEventTopPredictors{}
+
+				for j := 0; j < int(util.RandomInt(10))+1; j++ {
+					t := models.PredictionEventSubEventTopPredictors{
+						UserID:            util.RandomUserID(),
+						UserLogin:         "testLogin",
+						UserName:          "testLogin",
+						ChannelPointsUsed: int(util.RandomInt(10*1000)) + 100,
+					}
+					if params.Trigger == "prediction-lock" || params.Trigger == "prediction-end" {
+						if i == 0 {
+							t.ChannelPointsWon = intPointer(t.ChannelPointsUsed * 2)
+						} else {
+							t.ChannelPointsWon = intPointer(0)
+						}
+					}
+					tp = append(tp, t)
+					o.TopPredictors = &tp
+				}
+			}
+
+			outcomes = append(outcomes, o)
+		}
+
+		body := &models.PredictionEventSubResponse{
+			Subscription: models.EventsubSubscription{
+				ID:      params.ID,
+				Status:  "enabled",
+				Type:    triggerMapping[params.Transport][params.Trigger],
+				Version: "1",
+				Condition: models.EventsubCondition{
+					BroadcasterUserID: params.ToUserID,
+				},
+				Transport: models.EventsubTransport{
+					Method:   "webhook",
+					Callback: "null",
+				},
+				Cost:      0,
+				CreatedAt: util.GetTimestamp().Format(time.RFC3339Nano),
+			},
+			Event: models.PredictionEventSubEvent{
+				ID:                   util.RandomGUID(),
+				BroadcasterUserID:    params.ToUserID,
+				BroadcasterUserLogin: params.ToUserName,
+				BroadcasterUserName:  params.ToUserName,
+				Title:                params.Description,
+				Outcomes:             outcomes,
+				StartedAt:            util.GetTimestamp().Format(time.RFC3339Nano),
+			},
+		}
+
+		if params.Trigger == "prediction-begin" || params.Trigger == "prediction-progress" {
+			body.Event.LocksAt = util.GetTimestamp().Add(time.Minute * 10).Format(time.RFC3339Nano)
+		} else if params.Trigger == "prediction-lock" {
+			body.Event.LockedAt = util.GetTimestamp().Add(time.Minute * 10).Format(time.RFC3339Nano)
+		} else if params.Trigger == "prediction-end" {
+			body.Event.WinningOutcomeID = outcomes[0].ID
+			body.Event.EndedAt = util.GetTimestamp().Add(time.Minute * 10).Format(time.RFC3339Nano)
+			body.Event.Status = "resolved"
+		}
+
+		event, err = json.Marshal(body)
+		if err != nil {
+			return events.MockEventResponse{}, err
+		}
+	default:
+		return events.MockEventResponse{}, nil
+	}
+
+	return events.MockEventResponse{
+		ID:       params.ID,
+		JSON:     event,
+		FromUser: params.FromUserID,
+		ToUser:   params.ToUserID,
+	}, nil
+}
+
+func (e Event) ValidTransport(t string) bool {
+	return transportsSupported[t]
+}
+
+func (e Event) ValidTrigger(t string) bool {
+	for _, ts := range triggerSupported {
+		if ts == t {
+			return true
+		}
+	}
+	return false
+}
+func (e Event) GetTopic(transport string, trigger string) string {
+	return triggerMapping[transport][trigger]
+}
+
+func intPointer(i int) *int {
+	return &i
+}

--- a/internal/events/types/prediction/prediction_test.go
+++ b/internal/events/types/prediction/prediction_test.go
@@ -1,0 +1,115 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package prediction
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/test_setup"
+)
+
+var fromUser = "1234"
+var toUser = "4567"
+
+func TestEventSub(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportEventSub,
+		Trigger:    "prediction-begin",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.PredictionEventSubResponse
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	params = *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportEventSub,
+		Trigger:    "prediction-progress",
+	}
+
+	r, err = Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	body = models.PredictionEventSubResponse{}
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	params = *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportEventSub,
+		Trigger:    "prediction-lock",
+	}
+
+	r, err = Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	body = models.PredictionEventSubResponse{}
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	params = *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  models.TransportEventSub,
+		Trigger:    "prediction-end",
+	}
+
+	r, err = Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	body = models.PredictionEventSubResponse{}
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+}
+
+func TestFakeTransport(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID: fromUser,
+		ToUserID:   toUser,
+		Transport:  "fake_transport",
+		Trigger:    "unsubscribe",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+	a.Empty(r)
+}
+func TestValidTrigger(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.ValidTrigger("prediction-begin")
+	a.Equal(true, r)
+
+	r = Event{}.ValidTrigger("notgift")
+	a.Equal(false, r)
+}
+
+func TestValidTransport(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.ValidTransport(models.TransportEventSub)
+	a.Equal(true, r)
+
+	r = Event{}.ValidTransport("noteventsub")
+	a.Equal(false, r)
+}
+func TestGetTopic(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.GetTopic(models.TransportEventSub, "prediction-begin")
+	a.NotNil(r)
+}

--- a/internal/events/types/raid/raid_test.go
+++ b/internal/events/types/raid/raid_test.go
@@ -27,7 +27,7 @@ func TestEventSub(t *testing.T) {
 	r, err := Event{}.GenerateEvent(params)
 	a.Nil(err)
 
-	var body models.SubEventSubResponse // replace with actual value
+	var body models.SubEventSubResponse
 	err = json.Unmarshal(r.JSON, &body)
 	a.Nil(err)
 

--- a/internal/events/types/stream_change/stream_change_event.go
+++ b/internal/events/types/stream_change/stream_change_event.go
@@ -37,8 +37,10 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	if params.Description == "" {
 		params.Description = "Example title from the CLI!"
 	}
-	if params.ItemID == "" {
-		params.ItemID = "509658"
+	if params.ItemID == "" && params.GameID == "" {
+		params.GameID = "509658"
+	} else if params.ItemID != "" && params.GameID == "" {
+		params.GameID = params.ItemID
 	}
 	if params.ItemName == "" {
 		params.ItemName = "Just Chatting"
@@ -69,7 +71,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				BroadcasterUserName:  params.ToUserName,
 				StreamTitle:          params.Description,
 				StreamLanguage:       "en",
-				StreamCategoryID:     params.ItemID,
+				StreamCategoryID:     params.GameID,
 				StreamCategoryName:   params.ItemName,
 				IsMature:             false,
 			},
@@ -86,8 +88,8 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 					BroadcasterUserID:    params.ToUserID,
 					BroadcasterUserLogin: params.ToUserName,
 					BroadcasterUserName:  params.ToUserName,
-					StreamCategoryID:     params.ItemID,
-					StreamCategoryName:   "Just Chatting",
+					StreamCategoryID:     params.GameID,
+					StreamCategoryName:   params.ItemName,
 					StreamType:           "live",
 					StreamTitle:          params.Description,
 					StreamViewerCount:    9848,

--- a/internal/events/types/stream_change/stream_change_event_test.go
+++ b/internal/events/types/stream_change/stream_change_event_test.go
@@ -40,7 +40,7 @@ func TestEventSub(t *testing.T) {
 		ToUserID:   toUser,
 		Transport:  models.TransportEventSub,
 		Trigger:    "stream_change",
-		ItemID:     "1234",
+		GameID:     "1234",
 	}
 
 	r, err = Event{}.GenerateEvent(params)
@@ -65,7 +65,7 @@ func TestWebSubStreamChange(t *testing.T) {
 		Transport:   models.TransportWebSub,
 		Trigger:     "stream-change",
 		Description: newStreamTitle,
-		ItemID:      "1234",
+		GameID:      "1234",
 	}
 
 	r, err := Event{}.GenerateEvent(params)

--- a/internal/events/types/subscription_message/subscription_message.go
+++ b/internal/events/types/subscription_message/subscription_message.go
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package subscribe
+package subscription_message
 
 import (
 	"encoding/json"
@@ -12,24 +12,15 @@ import (
 )
 
 var transportsSupported = map[string]bool{
-	models.TransportWebSub:   true,
+	models.TransportWebSub:   false,
 	models.TransportEventSub: true,
 }
 
-var triggerSupported = []string{"subscribe", "gift", "unsubscribe", "subscribe-end"}
+var triggerSupported = []string{"subscribe-message"}
 
 var triggerMapping = map[string]map[string]string{
-	models.TransportWebSub: {
-		"subscribe":     "subscriptions.subscribe",
-		"unsubscribe":   "subscriptions.unsubscribe",
-		"gift":          "subscriptions.subscribe",
-		"subscribe-end": "",
-	},
 	models.TransportEventSub: {
-		"subscribe":     "channel.subscribe",
-		"unsubscribe":   "channel.unsubscribe",
-		"gift":          "channel.subscribe",
-		"subscribe-end": "channel.subscription.end",
+		"subscribe-message": "channel.subscription.message",
 	},
 }
 
@@ -38,26 +29,14 @@ type Event struct{}
 func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEventResponse, error) {
 	var event []byte
 	var err error
-	var giftUserID string
-	var giftUserName string
 
-	if params.Trigger == "gift" {
-		params.IsGift = true
-	}
-
-	if params.IsGift == true {
-		giftUserID = util.RandomUserID()
-		giftUserName = "testGifter"
-	}
-
-	if params.IsAnonymous == true {
-		giftUserID = "274598607"
-		giftUserName = "ananonymousgifter"
+	if params.Cost == 0 {
+		params.Cost = util.RandomInt(120) + 1
 	}
 
 	switch params.Transport {
 	case models.TransportEventSub:
-		body := *&models.EventsubResponse{
+		body := &models.SubscribeMessageEventSubResponse{
 			Subscription: models.EventsubSubscription{
 				ID:      params.ID,
 				Status:  "enabled",
@@ -73,7 +52,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				Cost:      0,
 				CreatedAt: util.GetTimestamp().Format(time.RFC3339Nano),
 			},
-			Event: models.SubEventSubEvent{
+			Event: models.SubscribeMessageEventSubEvent{
 				UserID:               params.FromUserID,
 				UserLogin:            params.FromUserName,
 				UserName:             params.FromUserName,
@@ -81,40 +60,30 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				BroadcasterUserLogin: params.ToUserName,
 				BroadcasterUserName:  params.ToUserName,
 				Tier:                 "1000",
-				IsGift:               params.IsGift,
+				Message: models.SubscribeMessageEventSubMessage{
+					Text: "Hello from the Twitch CLI! twitchdevLeek",
+					Emotes: []models.SubscribeMessageEventSubMessageEmote{
+						{
+							Begin: 26,
+							End:   39,
+							ID:    "304456816",
+						},
+					},
+				},
+				CumulativeMonths: int(params.Cost) + int(util.RandomInt(10)),
+				DurationMonths:   1,
 			},
 		}
 
+		if !params.IsAnonymous {
+			streak := int(params.Cost)
+			body.Event.StreakMonths = &streak
+		}
 		event, err = json.Marshal(body)
 		if err != nil {
 			return events.MockEventResponse{}, err
 		}
-	case models.TransportWebSub:
-		body := *&models.SubWebSubResponse{
-			Data: []models.SubWebSubResponseData{
-				{
-					ID:             params.ID,
-					EventType:      triggerMapping[params.Transport][params.Trigger],
-					EventTimestamp: util.GetTimestamp().Format(time.RFC3339),
-					Version:        "1.0",
-					EventData: models.SubWebSubEventData{
-						BroadcasterID:   params.ToUserID,
-						BroadcasterName: params.ToUserName,
-						UserID:          params.FromUserID,
-						UserName:        params.FromUserID,
-						Tier:            "1000",
-						PlanName:        "Tier 1 Test Sub",
-						IsGift:          params.IsGift,
-						GifterID:        giftUserID,
-						GifterName:      giftUserName,
-					},
-				},
-			}}
 
-		event, err = json.Marshal(body)
-		if err != nil {
-			return events.MockEventResponse{}, err
-		}
 	default:
 		return events.MockEventResponse{}, nil
 	}
@@ -139,7 +108,6 @@ func (e Event) ValidTrigger(t string) bool {
 	}
 	return false
 }
-
 func (e Event) GetTopic(transport string, trigger string) string {
 	return triggerMapping[transport][trigger]
 }

--- a/internal/events/types/subscription_message/subscription_message_test.go
+++ b/internal/events/types/subscription_message/subscription_message_test.go
@@ -29,7 +29,7 @@ func TestEventSub(t *testing.T) {
 	r, err := Event{}.GenerateEvent(params)
 	a.Nil(err)
 
-	var body models.SubscribeMessageEventSubResponse // replace with actual value
+	var body models.SubscribeMessageEventSubResponse
 	err = json.Unmarshal(r.JSON, &body)
 	a.Nil(err)
 	a.Equal(&ten, body.Event.StreakMonths)

--- a/internal/events/types/types.go
+++ b/internal/events/types/types.go
@@ -6,38 +6,48 @@ import (
 	"errors"
 
 	"github.com/twitchdev/twitch-cli/internal/events"
-	"github.com/twitchdev/twitch-cli/internal/events/types/authorization_revoke"
+	"github.com/twitchdev/twitch-cli/internal/events/types/authorization"
+	"github.com/twitchdev/twitch-cli/internal/events/types/ban"
 	"github.com/twitchdev/twitch-cli/internal/events/types/channel_points_redemption"
 	"github.com/twitchdev/twitch-cli/internal/events/types/channel_points_reward"
 	"github.com/twitchdev/twitch-cli/internal/events/types/cheer"
+	"github.com/twitchdev/twitch-cli/internal/events/types/drop"
 	"github.com/twitchdev/twitch-cli/internal/events/types/extension_transaction"
 	"github.com/twitchdev/twitch-cli/internal/events/types/follow"
+	"github.com/twitchdev/twitch-cli/internal/events/types/gift"
 	"github.com/twitchdev/twitch-cli/internal/events/types/hype_train"
 	"github.com/twitchdev/twitch-cli/internal/events/types/moderator_change"
+	"github.com/twitchdev/twitch-cli/internal/events/types/poll"
+	"github.com/twitchdev/twitch-cli/internal/events/types/prediction"
 	"github.com/twitchdev/twitch-cli/internal/events/types/raid"
 	"github.com/twitchdev/twitch-cli/internal/events/types/stream_change"
 	"github.com/twitchdev/twitch-cli/internal/events/types/streamdown"
 	"github.com/twitchdev/twitch-cli/internal/events/types/streamup"
 	"github.com/twitchdev/twitch-cli/internal/events/types/subscribe"
-	"github.com/twitchdev/twitch-cli/internal/events/types/ban"
+	"github.com/twitchdev/twitch-cli/internal/events/types/subscription_message"
 )
 
 func All() []events.MockEvent {
 	return []events.MockEvent{
-		authorization_revoke.Event{},
+		authorization.Event{},
+		ban.Event{},
 		channel_points_redemption.Event{},
 		channel_points_reward.Event{},
 		cheer.Event{},
+		drop.Event{},
 		extension_transaction.Event{},
 		follow.Event{},
+		gift.Event{},
 		hype_train.Event{},
+		moderator_change.Event{},
+		poll.Event{},
+		prediction.Event{},
 		raid.Event{},
-		subscribe.Event{},
 		stream_change.Event{},
 		streamup.Event{},
 		streamdown.Event{},
-		moderator_change.Event{},
-		ban.Event{},
+		subscribe.Event{},
+		subscription_message.Event{},
 	}
 }
 

--- a/internal/models/drops.go
+++ b/internal/models/drops.go
@@ -2,17 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 package models
 
-type DropsEntitlementsData struct {
-	ID        string `json:"id"`
-	BenefitID string `json:"benefit_id"`
-	Timestamp string `json:"timestamp"`
-	UserID    string `json:"user_id"`
-	GameID    string `json:"game_id"`
+type DropsEntitlementEventSubResponse struct {
+	Subscription EventsubSubscription            `json:"subscription"`
+	Events       []DropsEntitlementEventSubEvent `json:"events"`
 }
 
-type DropsEntitlementsResponse struct {
-	Pagination struct {
-		Cursor string `json:"cursor"`
-	} `json:"pagination"`
-	Data []DropsEntitlementsData `json:"data"`
+type DropsEntitlementEventSubEvent struct {
+	ID   string                            `json:"id"`
+	Data DropsEntitlementEventSubEventData `json:"data"`
+}
+type DropsEntitlementEventSubEventData struct {
+	EntitlementID  string `json:"entitlement_id"`
+	BenefitID      string `json:"benefit_id"`
+	CampaignID     string `json:"campaign_id"`
+	OrganizationID string `json:"organization_id"`
+	CreatedAt      string `json:"created_at"`
+	UserID         string `json:"user_id"`
+	UserName       string `json:"user_name"`
+	UserLogin      string `json:"user_login"`
+	CategoryID     string `json:"category_id"`
+	CategoryName   string `json:"category_name"`
 }

--- a/internal/models/eventsub.go
+++ b/internal/models/eventsub.go
@@ -24,6 +24,7 @@ type EventsubCondition struct {
 	FromBroadcasterUserID string `json:"from_broadcaster_user_id,omitempty"`
 	ClientID              string `json:"client_id,omitempty"`
 	ExtensionClientID     string `json:"extension_client_id,omitempty"`
+	OrganizationID        string `json:"organization_id,omitempty"`
 }
 
 type EventsubResponse struct {

--- a/internal/models/poll.go
+++ b/internal/models/poll.go
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package models
+
+type PollEventSubResponse struct {
+	Subscription EventsubSubscription `json:"subscription"`
+	Event        PollEventSubEvent    `json:"event"`
+}
+
+type PollEventSubEvent struct {
+	ID                   string                      `json:"id"`
+	BroadcasterUserID    string                      `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string                      `json:"broadcaster_user_login"`
+	BroadcasterUserName  string                      `json:"broadcaster_user_name"`
+	Title                string                      `json:"title"`
+	Choices              []PollEventSubEventChoice   `json:"choices"`
+	BitsVoting           PollEventSubEventGoodVoting `json:"bits_voting"`
+	ChannelPointsVoting  PollEventSubEventGoodVoting `json:"channel_points_voting"`
+	Status               string                      `json:"status,omitempty"`
+	StartedAt            string                      `json:"started_at"`
+	EndsAt               string                      `json:"ends_at,omitempty"`
+	EndedAt              string                      `json:"ended_at,omitempty"`
+}
+
+type PollEventSubEventChoice struct {
+	ID                 string `json:"id"`
+	Title              string `json:"title"`
+	BitsVotes          *int   `json:"bits_votes,omitempty"`
+	ChannelPointsVotes *int   `json:"channel_points_votes,omitempty"`
+	Votes              *int   `json:"votes,omitempty"`
+}
+
+type PollEventSubEventGoodVoting struct {
+	IsEnabled     bool `json:"is_enabled"`
+	AmountPerVote int  `json:"amount_per_vote"`
+}

--- a/internal/models/prediction.go
+++ b/internal/models/prediction.go
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package models
+
+type PredictionEventSubResponse struct {
+	Subscription EventsubSubscription    `json:"subscription"`
+	Event        PredictionEventSubEvent `json:"event"`
+}
+
+type PredictionEventSubEvent struct {
+	ID                   string                            `json:"id"`
+	BroadcasterUserID    string                            `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string                            `json:"broadcaster_user_login"`
+	BroadcasterUserName  string                            `json:"broadcaster_user_name"`
+	Title                string                            `json:"title"`
+	WinningOutcomeID     string                            `json:"winning_outcome_id,omitempty"`
+	Outcomes             []PredictionEventSubEventOutcomes `json:"outcomes"`
+	StartedAt            string                            `json:"started_at"`
+	LocksAt              string                            `json:"locks_at,omitempty"`
+	LockedAt             string                            `json:"locked_at,omitempty"`
+	EndedAt              string                            `json:"ended_at,omitempty"`
+	Status               string                            `json:"status,omitempty"`
+}
+
+type PredictionEventSubEventOutcomes struct {
+	ID            string                                  `json:"id"`
+	Title         string                                  `json:"title"`
+	Color         string                                  `json:"color"`
+	Users         *int                                    `json:"users,omitempty"`
+	ChannelPoints *int                                    `json:"channel_points,omitempty"`
+	TopPredictors *[]PredictionEventSubEventTopPredictors `json:"top_predictors,omitempty"`
+}
+
+type PredictionEventSubEventTopPredictors struct {
+	UserID            string `json:"user_id"`
+	UserLogin         string `json:"user_login"`
+	UserName          string `json:"user_name"`
+	ChannelPointsWon  *int   `json:"channel_points_won"`
+	ChannelPointsUsed int    `json:"channel_points_used"`
+}

--- a/internal/models/subs.go
+++ b/internal/models/subs.go
@@ -41,3 +41,51 @@ type SubEventSubEvent struct {
 	Tier                 string `json:"tier"`
 	IsGift               bool   `json:"is_gift"`
 }
+
+type GiftEventSubResponse struct {
+	Subscription EventsubSubscription `json:"subscription"`
+	Event        GiftEventSubEvent    `json:"event"`
+}
+
+type GiftEventSubEvent struct {
+	UserID               string `json:"user_id"`
+	UserLogin            string `json:"user_login"`
+	UserName             string `json:"user_name"`
+	BroadcasterUserID    string `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	BroadcasterUserName  string `json:"broadcaster_user_name"`
+	Tier                 string `json:"tier"`
+	Total                int    `json:"total"`
+	IsAnonymous          bool   `json:"is_anonymous"`
+	CumulativeTotal      *int   `json:"cumulative_total"`
+}
+
+type SubscribeMessageEventSubResponse struct {
+	Subscription EventsubSubscription          `json:"subscription"`
+	Event        SubscribeMessageEventSubEvent `json:"event"`
+}
+
+type SubscribeMessageEventSubEvent struct {
+	UserID               string                          `json:"user_id"`
+	UserLogin            string                          `json:"user_login"`
+	UserName             string                          `json:"user_name"`
+	BroadcasterUserID    string                          `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string                          `json:"broadcaster_user_login"`
+	BroadcasterUserName  string                          `json:"broadcaster_user_name"`
+	Tier                 string                          `json:"tier"`
+	Message              SubscribeMessageEventSubMessage `json:"message"`
+	CumulativeMonths     int                             `json:"cumulative_months"`
+	StreakMonths         *int                            `json:"streak_months"`
+	DurationMonths       int                             `json:"duration_months"`
+}
+
+type SubscribeMessageEventSubMessage struct {
+	Text   string                                 `json:"text"`
+	Emotes []SubscribeMessageEventSubMessageEmote `json:"emotes"`
+}
+
+type SubscribeMessageEventSubMessageEmote struct {
+	Begin int    `json:"begin"`
+	End   int    `json:"end"`
+	ID    string `json:"id"`
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Updates the EventSub topics to match the new topics; addresses #68 as a result.

## Description of Changes: 

- Adds Authorization Grant as `grant`
- Adds Polls events
- Adds Predictions events
- Adds Channel Gifts events
- Adds Subscription Message event
- Adds Drops entitlements event
- Adds Subscription end event
- Updates documentation to match
- Fixed small issue with .gitignore

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
