### PR TITLE
Updating ban events to match production

### DIFF
--- a/docs/mock-api.md
+++ b/docs/mock-api.md
@@ -20,8 +20,9 @@ The `mock-api` product has two primary functions. The first is to generate so-ca
 * Teams
 * Users
 
-The second is the actual server used to mock the endpoints. In the next iteration, you will be able to edit these and add further ones manually (for example, making a user with specific attributes), but for the beta we won't be providing this functionality as the current `generate` feature will make all of these (and more),
+The second is the actual server used to mock the endpoints. In the next iteration, you will be able to edit these and add further ones manually (for example, making a user with specific attributes), but for the beta we won't be providing this functionality as the current `generate` feature will make all of these (and more).
 
+As of the 1.1 release, this product is in an **open beta** and any bugs should be filed via GitHub Issues. Given the breadth of the tool, it is likely you may run across oddities; please fill out an issue if that is the case. 
 
 ## generate
 

--- a/docs/mock-api.md
+++ b/docs/mock-api.md
@@ -40,18 +40,12 @@ None.
 
 ## start
 
-The `start` function starts a new mock server for use with testing functionality. Currently, this replicates a large majority of the current API endpoints on the new API, but are ommitting: 
+The `start` function starts a new mock server for use with testing functionality. Currently, this replicates a large majority of the current API endpoints on the new API, but are omitting: 
 
-* GET /analytics/extensions
-* GET /analytics/games
-* GET /extensions/transactions
-* POST /eventsub/subscriptions
-* DELETE /eventsub/subscriptions
-* GET /eventsub/subscriptions
-* GET /users/extensions/list
-* GET /users/extensions
-* PUT /users/extensions
-* GET /webhooks/subscriptions
+* Extensions endpoints
+* Code entitlement endpoints
+* Websub endpoints
+* EventSub endpoints
 
 For many of these, we are exploring how to better integrate this with existing features (for example, allowing events to be triggered on unit creation or otherwise), and for others, the value is minimal compared to the docs. All other endpoints should be currently supported, however it is possible to be out of date- if so, [please raise an issue](https://github.com/twitchdev/twitch-cli/issues). 
 

--- a/internal/database/moderation.go
+++ b/internal/database/moderation.go
@@ -40,13 +40,17 @@ type ModeratorActionEvent struct {
 }
 
 type BanActionEvent struct {
-	BroadcasterID    string  `db:"broadcaster_id" json:"broadcaster_id"`
-	BroadcasterLogin string  `db:"broadcaster_login" json:"broadcaster_login"`
-	BroadcasterName  string  `db:"broadcaster_name" json:"broadcaster_name"`
-	UserID           string  `db:"user_id" json:"user_id"`
-	UserLogin        string  `db:"user_login" json:"user_login"`
-	UserName         string  `db:"user_name" json:"user_name"`
-	ExpiresAt        *string `db:"expires_at" json:"expires_at"`
+	BroadcasterID      string  `db:"broadcaster_id" json:"broadcaster_id"`
+	BroadcasterLogin   string  `db:"broadcaster_login" json:"broadcaster_login"`
+	BroadcasterName    string  `db:"broadcaster_name" json:"broadcaster_name"`
+	UserID             string  `db:"user_id" json:"user_id"`
+	UserLogin          string  `db:"user_login" json:"user_login"`
+	UserName           string  `db:"user_name" json:"user_name"`
+	ExpiresAt          *string `db:"expires_at" json:"expires_at"`
+	Reason             string  `json:"reason"`
+	ModeratorID        string  `json:"moderator_id"`
+	ModeratorUserLogin string  `json:"moderator_login"`
+	ModeratorUserName  string  `json:"moderator_user_name"`
 }
 
 type BanEvent struct {
@@ -57,10 +61,14 @@ type BanEvent struct {
 	BanActionEvent `json:"event_data"`
 }
 type Ban struct {
-	UserID    string  `db:"user_id" json:"user_id"`
-	UserLogin string  `db:"user_login" json:"user_login"`
-	UserName  string  `db:"user_name" json:"user_name"`
-	ExpiresAt *string `db:"expires_at" json:"expires_at"`
+	UserID             string  `db:"user_id" json:"user_id"`
+	UserLogin          string  `db:"user_login" json:"user_login"`
+	UserName           string  `db:"user_name" json:"user_name"`
+	ExpiresAt          *string `db:"expires_at" json:"expires_at"`
+	Reason             string  `json:"reason"`
+	ModeratorID        string  `json:"moderator_id"`
+	ModeratorUserLogin string  `json:"moderator_login"`
+	ModeratorUserName  string  `json:"moderator_user_name"`
 }
 
 var es = ""
@@ -192,6 +200,7 @@ func (q *Query) GetBans(p UserRequestParams) (*DBResponse, error) {
 		if b.ExpiresAt == nil {
 			b.ExpiresAt = &es
 		}
+		b.Reason = "CLI ban"
 		r = append(r, b)
 	}
 	dbr := DBResponse{
@@ -228,6 +237,7 @@ func (q *Query) GetBanEvents(p UserRequestParams) (*DBResponse, error) {
 		if b.ExpiresAt == nil {
 			b.ExpiresAt = &es
 		}
+		b.Reason = "CLI ban"
 		r = append(r, b)
 	}
 	dbr := DBResponse{

--- a/internal/mock_api/endpoints/moderation/banned.go
+++ b/internal/mock_api/endpoints/moderation/banned.go
@@ -61,6 +61,12 @@ func getBans(w http.ResponseWriter, r *http.Request) {
 		mock_errors.WriteUnauthorized(w, "broadcaster_id does not match token")
 		return
 	}
+	broadcaster, err := db.NewQuery(r, 100).GetUser(database.User{ID: userCtx.UserID})
+	if err != nil {
+		mock_errors.WriteServerError(w, "error fetching broadcaster")
+		return
+	}
+
 	bans := []database.Ban{}
 	userIDs := r.URL.Query()["user_id"]
 	if len(userIDs) > 0 {
@@ -80,6 +86,11 @@ func getBans(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		bans = append(bans, dbr.Data.([]database.Ban)...)
+	}
+	for i := range bans {
+		bans[i].ModeratorID = broadcaster.ID
+		bans[i].ModeratorUserLogin = broadcaster.UserLogin
+		bans[i].ModeratorUserName = broadcaster.DisplayName
 	}
 	apiResponse := models.APIResponse{Data: bans}
 	if dbr.Cursor != "" {

--- a/internal/mock_api/endpoints/moderation/banned_events.go
+++ b/internal/mock_api/endpoints/moderation/banned_events.go
@@ -60,6 +60,13 @@ func getBanEvents(w http.ResponseWriter, r *http.Request) {
 		mock_errors.WriteUnauthorized(w, "broadcaster_id does not match token")
 		return
 	}
+
+	broadcaster, err := db.NewQuery(r, 100).GetUser(database.User{ID: userCtx.UserID})
+	if err != nil {
+		mock_errors.WriteServerError(w, "error fetching broadcaster")
+		return
+	}
+
 	bans := []database.BanEvent{}
 	userIDs := r.URL.Query()["user_id"]
 	if len(userIDs) > 0 {
@@ -79,6 +86,11 @@ func getBanEvents(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		bans = append(bans, dbr.Data.([]database.BanEvent)...)
+	}
+	for i := range bans {
+		bans[i].ModeratorID = broadcaster.ID
+		bans[i].ModeratorUserLogin = broadcaster.UserLogin
+		bans[i].ModeratorUserName = broadcaster.DisplayName
 	}
 	apiResponse := models.APIResponse{Data: bans}
 	if dbr.Cursor != "" {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Please include a description of the problem or feature this PR is addressing.

## Description of Changes: 

- Updates the ban events to match production (adds `reason` and moderator information); for now this is just the broadcaster's information as the "moderator"
- Updates docs to reflect current status

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
