### PR TITLE
add missing fields in helix endpoints

### DIFF
--- a/internal/database/moderation.go
+++ b/internal/database/moderation.go
@@ -26,7 +26,7 @@ type ModeratorAction struct {
 	ID                   string `db:"id" json:"id"`
 	EventType            string `db:"event_type" json:"event_type"`
 	EventTimestamp       string `db:"event_timestamp" json:"event_timestamp"`
-	EventVersion         string `db:"event_version" json:"event_version"`
+	EventVersion         string `db:"event_version" json:"version"`
 	ModeratorActionEvent `json:"event_data"`
 }
 
@@ -50,14 +50,14 @@ type BanActionEvent struct {
 	Reason             string  `json:"reason"`
 	ModeratorID        string  `json:"moderator_id"`
 	ModeratorUserLogin string  `json:"moderator_login"`
-	ModeratorUserName  string  `json:"moderator_user_name"`
+	ModeratorUserName  string  `json:"moderator_name"`
 }
 
 type BanEvent struct {
 	ID             string `db:"id" json:"id"`
 	EventType      string `db:"event_type" json:"event_type"`
 	EventTimestamp string `db:"event_timestamp" json:"event_timestamp"`
-	EventVersion   string `db:"event_version" json:"event_version"`
+	EventVersion   string `db:"event_version" json:"version"`
 	BanActionEvent `json:"event_data"`
 }
 type Ban struct {
@@ -68,7 +68,7 @@ type Ban struct {
 	Reason             string  `json:"reason"`
 	ModeratorID        string  `json:"moderator_id"`
 	ModeratorUserLogin string  `json:"moderator_login"`
-	ModeratorUserName  string  `json:"moderator_user_name"`
+	ModeratorUserName  string  `json:"moderator_name"`
 }
 
 var es = ""

--- a/internal/database/streams.go
+++ b/internal/database/streams.go
@@ -13,7 +13,7 @@ type Stream struct {
 	UserID      string   `db:"broadcaster_id" json:"user_id"`
 	UserLogin   string   `db:"broadcaster_login" json:"user_login" dbi:"false"`
 	UserName    string   `db:"broadcaster_name" json:"user_name" dbi:"false"`
-	StreamType  string   `db:"stream_type" json:"stream_type"`
+	StreamType  string   `db:"stream_type" json:"type"`
 	ViewerCount int      `db:"viewer_count" json:"viewer_count"`
 	StartedAt   string   `db:"started_at" json:"started_at"`
 	IsMature    bool     `db:"is_mature" json:"is_mature"`
@@ -24,7 +24,9 @@ type Stream struct {
 	CategoryName     sql.NullString `db:"category_name" json:"-" dbi:"false"`
 	RealCategoryName string         `json:"game_name"`
 	Title            string         `db:"title" json:"title" dbi:"false"`
-	Language         string         `db:"stream_language" json:"stream_language" dbi:"false"`
+	Language         string         `db:"stream_language" json:"language" dbi:"false"`
+	// calculated fields
+	ThumbnailURL string `json:"thumbnail_url"`
 }
 
 type StreamTag struct {
@@ -83,6 +85,7 @@ func (q *Query) GetStream(s Stream) (*DBResponse, error) {
 		if s.CategoryName.Valid {
 			s.RealCategoryName = s.CategoryName.String
 		}
+		s.ThumbnailURL = fmt.Sprintf("https://static-cdn.jtvnw.net/previews-ttv/live_user_%v-{width}x{height}.jpg", s.UserLogin)
 		r = append(r, s)
 	}
 

--- a/internal/database/subscriptions.go
+++ b/internal/database/subscriptions.go
@@ -4,6 +4,7 @@ package database
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 )
 
@@ -20,6 +21,8 @@ type Subscription struct {
 	GifterLogin      *sql.NullString `db:"gifter_login" json:"gifter_login,omitempty"`
 	Tier             string          `db:"tier" json:"tier"`
 	CreatedAt        string          `db:"created_at" json:"-"`
+	// calculated fields
+	PlanName string `json:"plan_name"`
 }
 
 type SubscriptionInsert struct {
@@ -50,6 +53,15 @@ func (q *Query) GetSubscriptions(s Subscription) (*DBResponse, error) {
 			log.Print(err)
 			return nil, err
 		}
+		plan := fmt.Sprintf("Channel Subscription (%v)", s.BroadcasterLogin)
+		switch s.Tier {
+		case "2000":
+			plan = plan + ": $9.99 Sub"
+		case "3000":
+			plan = plan + ": $24.99 Sub"
+		default:
+		}
+		s.PlanName = plan
 		r = append(r, s)
 	}
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Fixes missing / wrong fields in endpoint payloads

## Description of Changes: 

- Rename `ModerationAction` and `BanEvent` json `event_version` -> `version`
- Rename `BanActionEvent` and `Ban` json `moderator_user_name` -> `moderator_name`
- Rename `Stream` json `stream_type` -> `type`
- Rename `Stream` json `stream_language` -> `language`
- Add `ThumbnailURL` to `Stream`
- Add `PlanName` to `Subscriptions`

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)

