### PR TITLE
Adding missing ID field in Hype Train events

### DIFF
--- a/internal/events/types/hype_train/hype_train_event.go
+++ b/internal/events/types/hype_train/hype_train_event.go
@@ -63,6 +63,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				CreatedAt: util.GetTimestamp().Format(time.RFC3339Nano),
 			},
 			Event: models.HypeTrainEventSubEvent{
+				ID:                   params.ID,
 				BroadcasterUserID:    params.ToUserID,
 				BroadcasterUserLogin: params.ToUserName,
 				BroadcasterUserName:  params.ToUserName,

--- a/internal/models/hype_train.go
+++ b/internal/models/hype_train.go
@@ -42,6 +42,7 @@ type HypeTrainEventSubResponse struct {
 }
 
 type HypeTrainEventSubEvent struct {
+	ID                      string             `json:"id"`
 	BroadcasterUserID       string             `json:"broadcaster_user_id"`
 	BroadcasterUserLogin    string             `json:"broadcaster_user_login"`
 	BroadcasterUserName     string             `json:"broadcaster_user_name"`


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Adds missing `id` field in all hype-train events, per #89 (ignore mistyped branch name). 

## Description of Changes: 

- Adds missing `id` field in all hype-train events, per #89.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
