### PR TITLE
adds template field to api response

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -101,6 +101,8 @@ func NewRequest(method string, path string, queryParameters []string, body []byt
 			return
 		}
 
+		data.Template = apiResponse.Template
+
 		if resp.StatusCode > 299 || resp.StatusCode < 200 {
 			data = apiResponse
 			break

--- a/internal/models/api.go
+++ b/internal/models/api.go
@@ -8,6 +8,7 @@ type APIResponse struct {
 	Error      string                    `json:"error,omitempty"`
 	Status     int                       `json:"status,omitempty"`
 	Message    string                    `json:"message,omitempty"`
+	Template   string                    `json:"template,omitempty"`
 	Total      *int                      `json:"total,omitempty"`
 	DateRange  *BitsLeaderboardDateRange `json:"date_range,omitempty"`
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

With the addition of the `template` field on `/chat/emotes?broadcaster_id=`, there is a `template` field added to the API response, but isn't shown in `twitch api` calls. This adds it to the model so that it can unmarshal it.

## Description of Changes: 

- Adds template response

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
