### PR TITLE
 Mock API: Fixed invalid range for duration error message typo for Poll Post Endpoint

### DIFF
--- a/internal/mock_api/endpoints/polls/polls.go
+++ b/internal/mock_api/endpoints/polls/polls.go
@@ -157,7 +157,7 @@ func postPolls(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if body.Duration < 15 || body.Duration > 1800 {
-		mock_errors.WriteBadRequest(w, "duation must be at least 15 and at most 1800")
+		mock_errors.WriteBadRequest(w, "duration must be at least 15 and at most 1800")
 		return
 	}
 	poll := database.Poll{


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Nothing big, just fixing a typo in the mock api errors for the Create Poll/Post Poll Endpoint

## Description of Changes: 

- Changed duation -> duration

## Checklist

- [Yes ] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [Yes ] I have self-reviewed the changes being requested
- [ Yes] I have made comments on pieces of code that may be difficult to understand for other editors
- [ Yes] I have updated the documentation (if applicable)
