### PR TITLE
fixing copo & predictions bugs as filed

### DIFF
--- a/internal/database/channel_points_rewards.go
+++ b/internal/database/channel_points_rewards.go
@@ -18,7 +18,7 @@ type ChannelPointsReward struct {
 	Cost                             int            `db:"cost" json:"cost"`
 	Title                            string         `db:"title" dbs:"cpr.title" json:"title"`
 	RewardPrompt                     string         `db:"reward_prompt" json:"prompt"`
-	IsUserInputRequired              bool           `db:"is_user_input_required" json:"is_user_input_requird"`
+	IsUserInputRequired              bool           `db:"is_user_input_required" json:"is_user_input_required"`
 	MaxPerStream                     `json:"max_per_stream_setting"`
 	MaxPerUserPerStream              `json:"max_per_user_per_stream_setting"`
 	GlobalCooldown                   `json:"global_cooldown_setting"`

--- a/internal/events/types/prediction/prediction.go
+++ b/internal/events/types/prediction/prediction.go
@@ -16,7 +16,7 @@ var transportsSupported = map[string]bool{
 	models.TransportEventSub: true,
 }
 
-var triggerSupported = []string{"prediction-begin", "prediction-progress", "prediction-end"}
+var triggerSupported = []string{"prediction-begin", "prediction-progress", "prediction-end", "prediction-lock"}
 
 var triggerMapping = map[string]map[string]string{
 	models.TransportEventSub: {
@@ -56,7 +56,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 
 			if params.Trigger != "prediction-begin" {
 				tp := []models.PredictionEventSubEventTopPredictors{}
-
+				sum := 0
 				for j := 0; j < int(util.RandomInt(10))+1; j++ {
 					t := models.PredictionEventSubEventTopPredictors{
 						UserID:            util.RandomUserID(),
@@ -64,6 +64,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 						UserName:          "testLogin",
 						ChannelPointsUsed: int(util.RandomInt(10*1000)) + 100,
 					}
+					sum += t.ChannelPointsUsed
 					if params.Trigger == "prediction-lock" || params.Trigger == "prediction-end" {
 						if i == 0 {
 							t.ChannelPointsWon = intPointer(t.ChannelPointsUsed * 2)
@@ -74,6 +75,9 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 					tp = append(tp, t)
 					o.TopPredictors = &tp
 				}
+				length := len(*o.TopPredictors)
+				o.Users = &length
+				o.ChannelPoints = &sum
 			}
 
 			outcomes = append(outcomes, o)

--- a/internal/mock_api/endpoints/channel_points/rewards.go
+++ b/internal/mock_api/endpoints/channel_points/rewards.go
@@ -38,7 +38,7 @@ type PatchAndPostRewardBody struct {
 	RewardPrompt               string `json:"prompt"`
 	IsEnabled                  *bool  `json:"is_enabled"`
 	BackgroundColor            string `json:"background_color"`
-	IsUserInputRequired        bool   `json:"is_user_input_requird"`
+	IsUserInputRequired        bool   `json:"is_user_input_required"`
 	StreamMaxEnabled           bool   `json:"is_max_per_stream_enabled"`
 	StreamMaxCount             int    `json:"max_per_stream"`
 	StreamUserMaxEnabled       bool   `json:"is_max_per_user_per_stream_enabled"`


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

This fixes #97, #99, and #100. 

## Description of Changes: 

- Fixes issue with prediction-lock not being a valid event type
- Fixes an issue with `users` and `channel_points` not being in the response for Prediction events
- Fixes typo in Channel Points rewards

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
