### PR TITLE
Update the trigger EventSub code to use colors

### DIFF
--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -4,9 +4,10 @@ package trigger
 
 import (
 	"fmt"
-	"log"
+	"io/ioutil"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/twitchdev/twitch-cli/internal/database"
 	"github.com/twitchdev/twitch-cli/internal/events"
 	"github.com/twitchdev/twitch-cli/internal/events/types"
@@ -117,12 +118,18 @@ func Fire(p TriggerParameters) (string, error) {
 		}
 		defer resp.Body.Close()
 
+                body, err := ioutil.ReadAll(resp.Body)
+                if err != nil {
+                        return "", err
+                }
+
+                respTrigger := string(body)
 		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
 			color.New().Add(color.FgGreen).Println(fmt.Sprintf(`✔ Request Sent. Recieved Status Code: %v`, resp.StatusCode))
-			color.New().Add(color.FgGreen).Println(fmt.Sprintf(`✔ Server Said: %s`, resp.Body))
+			color.New().Add(color.FgGreen).Println(fmt.Sprintf(`✔ Server Said: %s`, respTrigger))
 		} else {
 			color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Invalid response. Recieved Status Code: %v`, resp.StatusCode))
-			color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Server Said: %s`, resp.Body))
+			color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Server Said: %s`, respTrigger))
 		}	
 	}
 

--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -117,7 +117,13 @@ func Fire(p TriggerParameters) (string, error) {
 		}
 		defer resp.Body.Close()
 
-		log.Println(fmt.Sprintf(`[%v] Request Sent`, resp.StatusCode))
+		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+			color.New().Add(color.FgGreen).Println(fmt.Sprintf(`✔ Request Sent. Recieved Status Code: %v`, resp.StatusCode))
+			color.New().Add(color.FgGreen).Println(fmt.Sprintf(`✔ Server Said: %s`, resp.Body))
+		} else {
+			color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Invalid response. Recieved Status Code: %v`, resp.StatusCode))
+			color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Server Said: %s`, resp.Body))
+		}	
 	}
 
 	return string(resp.JSON), nil


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

An eventsub trigger doesn't use color and/or alert the user "nicely" to a non 200 code

fixes #105 

## Description of Changes: 

- Add color output to eventsub trigger
- Add body/status code output to eventsub trigger

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (if applicable)
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
