### PR TITLE
Report on the content type of the remote API when event verify-subscription-ing

### DIFF
--- a/internal/events/verify/subscription_verify.go
+++ b/internal/events/verify/subscription_verify.go
@@ -94,10 +94,10 @@ func VerifyWebhookSubscription(p VerifyParameters) (VerifyResponse, error) {
 			r.IsChallengeValid = false
 		}
 
-		if resp.Header.Get('Content-Type') == 'text/plain' {
-			color.New().Add(color.FgGreen).Println(fmt.Sprintf(`✔ Valid content-type header. Received type %v`, resp.Header.Get('Content-Type')))
+		if resp.Header.Get("Content-Type") == "text/plain" {
+			color.New().Add(color.FgGreen).Println(fmt.Sprintf(`✔ Valid content-type header. Received type %v`, resp.Header.Get("Content-Type")))
 	        } else {
-			color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Invalid content-type header. Received type %v`, resp.Header.Get('Content-Type')))
+			color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Invalid content-type header. Received type %v`, resp.Header.Get("Content-Type")))
 	        }
 		
 		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {

--- a/internal/events/verify/subscription_verify.go
+++ b/internal/events/verify/subscription_verify.go
@@ -94,6 +94,12 @@ func VerifyWebhookSubscription(p VerifyParameters) (VerifyResponse, error) {
 			r.IsChallengeValid = false
 		}
 
+		if resp.Header.Get('Content-Type') == 'text/plain' {
+			color.New().Add(color.FgGreen).Println(fmt.Sprintf(`✔ Valid content-type header. Received type %v`, resp.Header.Get('Content-Type')))
+	        } else {
+			color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Invalid content-type header. Received type %v`, resp.Header.Get('Content-Type')))
+	        }
+		
 		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
 			color.New().Add(color.FgGreen).Println(fmt.Sprintf(`✔ Valid status code. Received status %v`, resp.StatusCode))
 			r.IsStatusValid = true


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Add a third test to the event sub verifiy function, to report what the content type is of the returned response

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
