### PR TITLE
Add `user.update` EventSub

### DIFF
--- a/internal/events/models.go
+++ b/internal/events/models.go
@@ -24,6 +24,7 @@ var triggerSupported = map[string]bool{
 	"goal-begin":          true,
 	"goal-progress":       true,
 	"goal-end":            true,
+	"user-update":         true,
 }
 
 var transportSupported = map[string]bool{

--- a/internal/events/types/types.go
+++ b/internal/events/types/types.go
@@ -26,6 +26,7 @@ import (
 	"github.com/twitchdev/twitch-cli/internal/events/types/streamup"
 	"github.com/twitchdev/twitch-cli/internal/events/types/subscribe"
 	"github.com/twitchdev/twitch-cli/internal/events/types/subscription_message"
+	"github.com/twitchdev/twitch-cli/internal/events/types/user"
 	"github.com/twitchdev/twitch-cli/internal/models"
 )
 
@@ -51,6 +52,7 @@ func All() []events.MockEvent {
 		subscribe.Event{},
 		subscription_message.Event{},
 		goal.Event{},
+		user_update.Event{},
 	}
 }
 

--- a/internal/events/types/user/user_update.go
+++ b/internal/events/types/user/user_update.go
@@ -65,7 +65,6 @@ func (e Event) GenerateEvent(p events.MockEventParameters) (events.MockEventResp
     return events.MockEventResponse{
         ID:             p.ID,
         JSON:           event,
-        FromUser:       p.FromUserID,
         ToUser:         p.ToUserID,
     }, nil
 }

--- a/internal/events/types/user/user_update.go
+++ b/internal/events/types/user/user_update.go
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package user_update
+
+import (
+    "encoding/json"
+    "time"
+
+    "github.com/twitchdev/twitch-cli/internal/events"
+    "github.com/twitchdev/twitch-cli/internal/models"
+    "github.com/twitchdev/twitch-cli/internal/util"
+)
+
+var transportsSupported = map[string]bool{
+    models.TransportEventSub: true,
+}
+var triggers = []string{"user.update"}
+
+var triggerMapping = map[string]map[string]string{
+    models.TransportEventSub: {
+        "user.update": "user.update",
+    },
+}
+
+type Event struct{}
+
+func (e Event) GenerateEvent(p events.MockEventParameters) (events.MockEventResponse, error) {
+    var event []byte
+    var err error
+
+    switch p.Transport {
+    case models.TransportEventSub:
+        body := models.EventsubResponse{
+            Subscription: models.EventsubSubscription{
+                ID:      p.ID,
+                Status:  "enabled",
+                Type:    "user.update",
+                Version: "1",
+                Condition: models.EventsubCondition{
+                    UserID : p.ToUserID,
+                },
+                Transport: models.EventsubTransport{
+                    Method:   "webhook",
+                    Callback: "null",
+                },
+                Cost:      0,
+                CreatedAt: util.GetTimestamp().Format(time.RFC3339Nano),
+            },
+            Event: models.UserUpdateEventSubEvent{
+                UserID:         p.ToUserID,
+                UserLogin:      p.ToUserName,
+                UserName:       p.ToUserName,
+                Description:    p.Description,
+            },
+        }
+
+        event, err = json.Marshal(body)
+        if err != nil {
+            return events.MockEventResponse{}, err
+        }
+    default:
+        return events.MockEventResponse{}, nil
+    }
+
+    return events.MockEventResponse{
+        ID:             p.ID,
+        JSON:           event,
+        FromUser:       p.FromUserID,
+        ToUser:         p.ToUserID,
+    }, nil
+}
+
+func (e Event) ValidTransport(transport string) bool {
+    return transportsSupported[transport]
+}
+
+func (e Event) ValidTrigger(trigger string) bool {
+    for _, t := range triggers {
+        if t == trigger {
+            return true
+        }
+    }
+    return false
+}
+func (e Event) GetTopic(transport string, trigger string) string {
+    return triggerMapping[transport][trigger]
+}
+func (e Event) GetEventSubAlias(t string) string {
+    // check for aliases
+    for trigger, topic := range triggerMapping[models.TransportEventSub] {
+        if topic == t {
+            return trigger
+        }
+    }
+    return ""
+}

--- a/internal/events/types/user/user_update_test.go
+++ b/internal/events/types/user/user_update_test.go
@@ -17,7 +17,7 @@ func TestEventSub(t *testing.T) {
     a := test_setup.SetupTestEnv(t)
 
     params := *&events.MockEventParameters{
-        UserID:     toUser,
+        ToUserID:     toUser,
         Transport:  models.TransportEventSub,
         Trigger:    "user.update",
     }
@@ -36,7 +36,7 @@ func TestFakeTransport(t *testing.T) {
     a := test_setup.SetupTestEnv(t)
 
     params := *&events.MockEventParameters{
-        UserID:     toUser,
+        ToUserID:     toUser,
         Transport:  "fake_transport",
         Trigger:    "unsubscribe",
     }

--- a/internal/events/types/user/user_update_test.go
+++ b/internal/events/types/user/user_update_test.go
@@ -19,7 +19,7 @@ func TestEventSub(t *testing.T) {
     params := *&events.MockEventParameters{
         UserID:     toUser,
         Transport:  models.TransportEventSub,
-        Trigger:    "user_update",
+        Trigger:    "user.update",
     }
 
     r, err := Event{}.GenerateEvent(params)

--- a/internal/events/types/user/user_update_test.go
+++ b/internal/events/types/user/user_update_test.go
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package user_update
+
+import (
+    "encoding/json"
+    "testing"
+
+    "github.com/twitchdev/twitch-cli/internal/events"
+    "github.com/twitchdev/twitch-cli/internal/models"
+    "github.com/twitchdev/twitch-cli/test_setup"
+)
+
+var toUser = "4567"
+
+func TestEventSub(t *testing.T) {
+    a := test_setup.SetupTestEnv(t)
+
+    params := *&events.MockEventParameters{
+        UserID:     toUser,
+        Transport:  models.TransportEventSub,
+        Trigger:    "user_update",
+    }
+
+    r, err := Event{}.GenerateEvent(params)
+    a.Nil(err)
+
+    var body models.StreamUpEventSubResponse
+    err = json.Unmarshal(r.JSON, &body)
+    a.Nil(err)
+
+    // write actual tests here (making sure you set appropriate values and the like) for eventsub
+}
+
+func TestFakeTransport(t *testing.T) {
+    a := test_setup.SetupTestEnv(t)
+
+    params := *&events.MockEventParameters{
+        UserID:     toUser,
+        Transport:  "fake_transport",
+        Trigger:    "unsubscribe",
+    }
+
+    r, err := Event{}.GenerateEvent(params)
+    a.Nil(err)
+    a.Empty(r)
+}
+func TestValidTrigger(t *testing.T) {
+    a := test_setup.SetupTestEnv(t)
+
+    r := Event{}.ValidTrigger("user.update")
+    a.Equal(true, r)
+
+    r = Event{}.ValidTrigger("notgift")
+    a.Equal(false, r)
+}
+
+func TestValidTransport(t *testing.T) {
+    a := test_setup.SetupTestEnv(t)
+
+    r := Event{}.ValidTransport(models.TransportEventSub)
+    a.Equal(true, r)
+
+    r = Event{}.ValidTransport("noteventsub")
+    a.Equal(false, r)
+}
+func TestGetTopic(t *testing.T) {
+    a := test_setup.SetupTestEnv(t)
+
+    r := Event{}.GetTopic(models.TransportEventSub, "user.update")
+    a.NotNil(r)
+}

--- a/internal/models/eventsub.go
+++ b/internal/models/eventsub.go
@@ -21,6 +21,7 @@ type EventsubTransport struct {
 type EventsubCondition struct {
 	BroadcasterUserID     string `json:"broadcaster_user_id,omitempty"`
 	ToBroadcasterUserID   string `json:"to_broadcaster_user_id,omitempty"`
+	UserID                string `json:"user_id,omitempty"`
 	FromBroadcasterUserID string `json:"from_broadcaster_user_id,omitempty"`
 	ClientID              string `json:"client_id,omitempty"`
 	ExtensionClientID     string `json:"extension_client_id,omitempty"`

--- a/internal/models/user_update.go
+++ b/internal/models/user_update.go
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package models
+
+type UserUpdateEventSubResponse struct {
+    Subscription EventsubSubscription  `json:"subscription"`
+    Event        StreamUpEventSubEvent `json:"event"`
+}
+
+type UserUpdateEventSubEvent struct {
+    UserID               string `json:"user_id"`
+    UserLogin            string `json:"user_login"`
+    UserName             string `json:"user_name"`
+    Description          string `json:"description"`
+}


### PR DESCRIPTION
> twitch event trigger user.update -F "URL" -s "YOURSECRET"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

One of my projects was erroring on a processing of `user.update` topic.
So I went to test it and found that the cli doesn't support it
This adds it

## Description of Changes: 

- Add a model in folder `user` of `user.update`
- Add a test for that model that might be wrong, not sure how to run tests
- Added UserId to the `EventsubCondition` model
- Enabled the mode in `type/stypes`

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
