### PR TITLE
Add a CORS header to the mock-api

### DIFF
--- a/internal/mock_api/mock_server/server.go
+++ b/internal/mock_api/mock_server/server.go
@@ -101,7 +101,7 @@ func loggerMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("%v %v", r.Method, r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("access-control-allow-origin", "*")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
 
 		next.ServeHTTP(w, r)
 	})

--- a/internal/mock_api/mock_server/server.go
+++ b/internal/mock_api/mock_server/server.go
@@ -101,6 +101,7 @@ func loggerMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("%v %v", r.Method, r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("access-control-allow-origin", "*")
 
 		next.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
## Problem/Feature

The mock-api is a great tool for building against partner- or affiliate-specific endpoints. The absence of CORS headers causes browsers to reject AJAX requests to the mock-api by default.

## Description of Changes: 

- Add a `Access-Control-Allow-Origin: *` header, same as the helix endpoint

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
