### PR TITLE
The "legacy" name for this trigger has the wrong eventsub topic name

### DIFF
--- a/internal/events/types/subscribe/sub_event.go
+++ b/internal/events/types/subscribe/sub_event.go
@@ -20,7 +20,7 @@ var triggerSupported = []string{"subscribe", "gift", "unsubscribe", "subscribe-e
 var triggerMapping = map[string]map[string]string{
 	models.TransportEventSub: {
 		"subscribe":     "channel.subscribe",
-		"unsubscribe":   "channel.unsubscribe",
+		"unsubscribe":   "channel.subscription.end",
 		"gift":          "channel.subscribe",
 		"subscribe-end": "channel.subscription.end",
 	},


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Please include a description of the problem or feature this PR is addressing.

## Description of Changes: 

```
barrycarlyon@Robyn ~ % twitch event trigger unsubscribe
{"subscription":{"id":"fd1f9269-148c-fc06-4c2f-996580207d91","status":"enabled","type":"channel.unsubscribe","version":"1","condition":{"broadcaster_user_id":"8594094"},"transport":{"method":"webhook","callback":"null"},"created_at":"2021-12-14T14:29:25.352469Z","cost":0},"event":{"user_id":"57434785","user_login":"testFromUser","user_name":"testFromUser","broadcaster_user_id":"8594094","broadcaster_user_login":"testBroadcaster","broadcaster_user_name":"testBroadcaster","tier":"1000","is_gift":false}}
```

fixed to

```
barrycarlyon@Robyn ~ % twitch event trigger unsubscribe
{"subscription":{"id":"9466cce5-dd5b-4af7-6178-0ffc3f7db3e8","status":"enabled","type":"channel.subscription.end","version":"1","condition":{"broadcaster_user_id":"33893692"},"transport":{"method":"webhook","callback":"null"},"created_at":"2021-12-14T14:30:37.098126Z","cost":0},"event":{"user_id":"37902996","user_login":"testFromUser","user_name":"testFromUser","broadcaster_user_id":"33893692","broadcaster_user_login":"testBroadcaster","broadcaster_user_name":"testBroadcaster","tier":"1000","is_gift":false}}
```

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
