### PR TITLE
Indicate required content-type for webhook subscription verification

### DIFF
--- a/internal/events/verify/subscription_verify.go
+++ b/internal/events/verify/subscription_verify.go
@@ -106,9 +106,9 @@ func VerifyWebhookSubscription(p VerifyParameters) (VerifyResponse, error) {
 			}
 		} else {
 			if charset != "" {
-				color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Invalid content-type header. Received type %v with charset %v`, mediatype, params["charset"]))
+				color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Invalid content-type header. Received type %v with charset %v. Expecting text/plain.`, mediatype, params["charset"]))
 			} else {
-				color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Invalid content-type header. Received type %v`, mediatype))
+				color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Invalid content-type header. Received type %v. Expecting text/plain.`, mediatype))
 			}
 		}
 


### PR DESCRIPTION
Since the documentation doesn't tell it (I looked thoroughly, but I might be wrong), I think it's a good idea to tell the user which content-type is awaited when verifying the webhook subscription.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

The problem I identified (maybe wrongly?) is that it is not specified in the official twitch api documentation which value the Content-Type header should have for the webhook subscription verification. Since I had to look into the source code of this project to get my answer (no hard feelings at all), I think it might be good to indicate to the users of the twitch-cli why their requests are invalid.

## Description of Changes: 

- Added the expected value in the two error messages that indicate that the Content-Type doesn't have the right value.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [ ] I have made comments on pieces of code that may be difficult to understand for other editors
- [ ] I have updated the documentation (if applicable)
