### PR TITLE
Use the calculated path in help message

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,14 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.twitch-cli/.twitch-cli.env)")
+
+	cfgFile, err := util.GetConfigPath()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", fmt.Sprintf("config file (default is %s)", cfgFile))
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Running the `twitch` command without any other arguments prints some help information. This help information includes this section:

```
Flags:
      --config string   config file (default is $HOME/.twitch-cli/.twitch-cli.env)
```

The path that is listed here appears to be a legacy value—on my machine it is incorrect. (macOS; the path is actually `$HOME/Library/Application Support/twitch-cli/.twitch-cli.env`).

## Description of Changes: 

This PR changes the help for the command root to display the actual calculated path of the config file instead of hardcoding a path.

I wasn't sure of the preferred approach to naming/error-handling, and it's been years since I've written any Go, so I tried to match the existing code as closely as possible. Feedback/changes absolutely welcome. 🙂

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
