### PR TITLE
fixes #135 and updates dockerfile to address issue

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,7 +53,7 @@ builds:
     goos:
       - windows
     goarch:
-      - 386 
+      - "386" 
 scoop:
   bucket:
     owner: twitchdev
@@ -97,6 +97,13 @@ archives:
     format_overrides:
     - goos: windows
       format: zip
+    wrap_in_directory: "true"
+    files:
+      - docs/*
+      - LICENSE.md
+      - NOTICE
+      - THIRD-PARTY
+      - README.md
 checksum:
   name_template: 'checksums.txt'
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -100,7 +100,7 @@ archives:
     wrap_in_directory: "true"
     files:
       - docs/*
-      - LICENSE.md
+      - LICENSE
       - NOTICE
       - THIRD-PARTY
       - README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM techknowlogick/xgo:latest
-RUN apt-get update && apt-get install curl -y
-RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
+RUN echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
+RUN apt-get update && apt-get install goreleaser -y
 
 ENTRYPOINT ["goreleaser"]


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

This addresses 2 issues related to the release process- #135 as well as the goreleaser script being deprecated. 

## Description of Changes: 

- Adds the `wrap_in_directory` flag to goreleaser to wrap the ZIP/Tar in a subfolder to avoid overwriting local files per #135 
- Changes `Dockerfile` to use `apt-get` instead of the hosted shell script

These changes should be transparent to end users; tested by running `make test-release` and making sure everything looked according to the changes. 

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
