### PR TITLE
bugfix: addressing hype train events issues #130 & #131

### DIFF
--- a/internal/events/types/hype_train/hype_train_event.go
+++ b/internal/events/types/hype_train/hype_train_event.go
@@ -45,7 +45,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1.0",
+				Version: "1",
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},

--- a/internal/models/hype_train.go
+++ b/internal/models/hype_train.go
@@ -22,7 +22,7 @@ type HypeTrainEventSubEvent struct {
 	BroadcasterUserName     string             `json:"broadcaster_user_name"`
 	Level                   int64              `json:"level,omitempty"`
 	Total                   int64              `json:"total"`
-	Progress                int64              `json:"progress,omitempty"`
+	Progress                *int64             `json:"progress,omitempty"`
 	Goal                    int64              `json:"goal,omitempty"`
 	TopContributions        []ContributionData `json:"top_contributions"`
 	LastContribution        ContributionData   `json:"last_contribution,omitempty"`


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Fixes #130 as the version was incorrectly put as "1.0" whereas that only applies to the REST API, not Events. 

## Description of Changes: 

- Changes the version to match the docs (https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelhype_trainbegin) and fixes #130 
- Changes the `progress` attribute to be properly shown and calculated; previously was thought to be a percentage progress but is in fact the event's contribution amount; this resolves #131 as a result

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
