### PR TITLE
Added is_paused flag for custom rewards POST and PATCH

### DIFF
--- a/internal/mock_api/endpoints/channel_points/rewards.go
+++ b/internal/mock_api/endpoints/channel_points/rewards.go
@@ -45,6 +45,7 @@ type PatchAndPostRewardBody struct {
 	StreamUserMaxCount         int    `json:"max_per_user_per_stream"`
 	GlobalCooldownEnabled      bool   `json:"is_global_cooldown_enabled"`
 	GlobalCooldownSeconds      int    `json:"global_cooldown_seconds"`
+	IsPaused                   bool   `json:"is_paused"`
 	ShouldRedemptionsSkipQueue bool   `json:"should_redemptions_skip_request_queue"`
 }
 
@@ -200,6 +201,7 @@ func postRewards(w http.ResponseWriter, r *http.Request) {
 			GlobalCooldownEnabled: body.GlobalCooldownEnabled,
 			GlobalCooldownSeconds: body.GlobalCooldownSeconds,
 		},
+		IsPaused:                   body.IsPaused,
 		ShouldRedemptionsSkipQueue: body.ShouldRedemptionsSkipQueue,
 	}
 
@@ -290,6 +292,7 @@ func patchRewards(w http.ResponseWriter, r *http.Request) {
 			GlobalCooldownEnabled: body.GlobalCooldownEnabled,
 			GlobalCooldownSeconds: body.GlobalCooldownSeconds,
 		},
+		IsPaused:                   body.IsPaused,
 		ShouldRedemptionsSkipQueue: body.ShouldRedemptionsSkipQueue,
 	}
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Addresses missing is_paused flag, mentioned in #137 

## Description of Changes: 

- Both POST and PATCH for custom rewards now supports is_paused flag.

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
