### PR TITLE
Fix typo in trigger_event

### DIFF
--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -133,10 +133,10 @@ func Fire(p TriggerParameters) (string, error) {
 
 		respTrigger := string(body)
 		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
-			color.New().Add(color.FgGreen).Println(fmt.Sprintf(`✔ Request Sent. Recieved Status Code: %v`, resp.StatusCode))
+			color.New().Add(color.FgGreen).Println(fmt.Sprintf(`✔ Request Sent. Received Status Code: %v`, resp.StatusCode))
 			color.New().Add(color.FgGreen).Println(fmt.Sprintf(`✔ Server Said: %s`, respTrigger))
 		} else {
-			color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Invalid response. Recieved Status Code: %v`, resp.StatusCode))
+			color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Invalid response. Received Status Code: %v`, resp.StatusCode))
 			color.New().Add(color.FgRed).Println(fmt.Sprintf(`✗ Server Said: %s`, respTrigger))
 		}
 	}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Fix minor typo in CLI output after an event is triggered

## Description of Changes: 

- correct spelling of word `received`

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [ ] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
