### PR TITLE
fix: set `Twitch-Eventsub-Subscription-Type` to correct type

### DIFF
--- a/internal/events/trigger/retrigger_event.go
+++ b/internal/events/trigger/retrigger_event.go
@@ -21,9 +21,14 @@ func RefireEvent(id string, p TriggerParameters) (string, error) {
 
 	p.Transport = res.Transport
 
-	e, err := types.GetByTriggerAndTransport(p.Event, p.Transport)
+	e, err := types.GetByTriggerAndTransport(res.Event, p.Transport)
 	if err != nil {
 		return "", err
+	}
+
+	topic := e.GetTopic(p.Transport, res.Event)
+	if topic == "" && e.GetEventSubAlias(res.Event) != "" {
+		topic = res.Event
 	}
 
 	if p.ForwardAddress != "" {
@@ -33,7 +38,7 @@ func RefireEvent(id string, p TriggerParameters) (string, error) {
 			ForwardAddress:      p.ForwardAddress,
 			Secret:              p.Secret,
 			JSON:                []byte(res.JSON),
-			Event:               res.Event,
+			Event:               topic,
 			Type:                EventSubMessageTypeNotification,
 			SubscriptionVersion: e.SubscriptionVersion(),
 		})

--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -118,7 +118,7 @@ func Fire(p TriggerParameters) (string, error) {
 			JSON:           resp.JSON,
 			Secret:         p.Secret,
 			ForwardAddress: p.ForwardAddress,
-			Event:          e.GetTopic(p.Transport, p.Event),
+			Event:          p.Event,
 			Type:           EventSubMessageTypeNotification,
 		})
 		if err != nil {

--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -110,7 +110,10 @@ func Fire(p TriggerParameters) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
+	topic := e.GetTopic(p.Transport, p.Event)
+	if topic == "" && e.GetEventSubAlias(p.Event) != "" {
+		topic = p.Event
+	}
 	if p.ForwardAddress != "" {
 		resp, err := ForwardEvent(ForwardParamters{
 			ID:             resp.ID,
@@ -118,7 +121,7 @@ func Fire(p TriggerParameters) (string, error) {
 			JSON:           resp.JSON,
 			Secret:         p.Secret,
 			ForwardAddress: p.ForwardAddress,
-			Event:          p.Event,
+			Event:          topic,
 			Type:           EventSubMessageTypeNotification,
 		})
 		if err != nil {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Fixes #163.

## Description of Changes: 

- Remove the call to `GetTopic` since at that point, we alredy have the event type.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
