### PR TITLE
fix: set `Twitch-Eventsub-Subscription-Version` correctly

### DIFF
--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -47,4 +47,7 @@ type MockEvent interface {
 
 	// Returns back the correct "trigger" if using the eventsub topic
 	GetEventSubAlias(trigger string) string
+
+	// Returns the subscription version for this event
+	SubscriptionVersion() string
 }

--- a/internal/events/trigger/forward_event.go
+++ b/internal/events/trigger/forward_event.go
@@ -16,14 +16,15 @@ import (
 )
 
 type ForwardParamters struct {
-	ID             string
-	ForwardAddress string
-	JSON           []byte
-	Transport      string
-	Secret         string
-	Event          string
-	Method         string
-	Type           string
+	ID                  string
+	ForwardAddress      string
+	JSON                []byte
+	Transport           string
+	Secret              string
+	Event               string
+	Method              string
+	Type                string
+	SubscriptionVersion string
 }
 
 type header struct {
@@ -41,10 +42,6 @@ var notificationHeaders = map[string][]header{
 		{
 			HeaderName:  `Twitch-Eventsub-Message-Retry`,
 			HeaderValue: `0`,
-		},
-		{
-			HeaderName:  `Twitch-Eventsub-Subscription-Version`,
-			HeaderValue: `test`,
 		},
 	},
 }
@@ -69,6 +66,7 @@ func ForwardEvent(p ForwardParamters) (*http.Response, error) {
 	case models.TransportEventSub:
 		req.Header.Set("Twitch-Eventsub-Message-Id", p.ID)
 		req.Header.Set("Twitch-Eventsub-Subscription-Type", p.Event)
+		req.Header.Set("Twitch-Eventsub-Subscription-Version", p.SubscriptionVersion)
 		switch p.Type {
 		case EventSubMessageTypeNotification:
 			req.Header.Add("Twitch-Eventsub-Message-Type", EventSubMessageTypeNotification)

--- a/internal/events/trigger/retrigger_event.go
+++ b/internal/events/trigger/retrigger_event.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/twitchdev/twitch-cli/internal/database"
+	"github.com/twitchdev/twitch-cli/internal/events/types"
 )
 
 func RefireEvent(id string, p TriggerParameters) (string, error) {
@@ -20,15 +21,21 @@ func RefireEvent(id string, p TriggerParameters) (string, error) {
 
 	p.Transport = res.Transport
 
+	e, err := types.GetByTriggerAndTransport(p.Event, p.Transport)
+	if err != nil {
+		return "", err
+	}
+
 	if p.ForwardAddress != "" {
 		resp, err := ForwardEvent(ForwardParamters{
-			ID:             id,
-			Transport:      res.Transport,
-			ForwardAddress: p.ForwardAddress,
-			Secret:         p.Secret,
-			JSON:           []byte(res.JSON),
-			Event:          res.Event,
-			Type:           EventSubMessageTypeNotification,
+			ID:                  id,
+			Transport:           res.Transport,
+			ForwardAddress:      p.ForwardAddress,
+			Secret:              p.Secret,
+			JSON:                []byte(res.JSON),
+			Event:               res.Event,
+			Type:                EventSubMessageTypeNotification,
+			SubscriptionVersion: e.SubscriptionVersion(),
 		})
 		defer resp.Body.Close()
 

--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -113,13 +113,14 @@ func Fire(p TriggerParameters) (string, error) {
 
 	if p.ForwardAddress != "" {
 		resp, err := ForwardEvent(ForwardParamters{
-			ID:             resp.ID,
-			Transport:      p.Transport,
-			JSON:           resp.JSON,
-			Secret:         p.Secret,
-			ForwardAddress: p.ForwardAddress,
-			Event:          e.GetTopic(p.Transport, p.Event),
-			Type:           EventSubMessageTypeNotification,
+			ID:                  resp.ID,
+			Transport:           p.Transport,
+			JSON:                resp.JSON,
+			Secret:              p.Secret,
+			ForwardAddress:      p.ForwardAddress,
+			Event:               e.GetTopic(p.Transport, p.Event),
+			Type:                EventSubMessageTypeNotification,
+			SubscriptionVersion: e.SubscriptionVersion(),
 		})
 		if err != nil {
 			return "", err

--- a/internal/events/types/_template/_event_name.go
+++ b/internal/events/types/_template/_event_name.go
@@ -72,3 +72,7 @@ func (e Event) GetEventSubAlias(t string) string {
 	}
 	return ""
 }
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
+}

--- a/internal/events/types/authorization/authorization.go
+++ b/internal/events/types/authorization/authorization.go
@@ -43,7 +43,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					ClientID: clientID,
 				},
@@ -100,4 +100,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/ban/ban.go
+++ b/internal/events/types/ban/ban.go
@@ -32,7 +32,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 
 	switch params.Transport {
 	case models.TransportEventSub:
-		e := models.BanEventSubEvent{
+		ban := models.BanEventSubEvent{
 			UserID:               params.FromUserID,
 			UserLogin:            params.FromUserName,
 			UserName:             params.FromUserName,
@@ -47,9 +47,9 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 		if params.Trigger == "ban" {
 			reason := "This is a test event"
 			endsAt := util.GetTimestamp().Format(time.RFC3339Nano)
-			e.Reason = &reason
-			e.EndsAt = &endsAt
-			e.IsPermanent = &params.IsPermanent
+			ban.Reason = &reason
+			ban.EndsAt = &endsAt
+			ban.IsPermanent = &params.IsPermanent
 		}
 
 		body := *&models.EventsubResponse{
@@ -57,7 +57,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -68,7 +68,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				Cost:      0,
 				CreatedAt: util.GetTimestamp().Format(time.RFC3339Nano),
 			},
-			Event: e,
+			Event: ban,
 		}
 
 		event, err = json.Marshal(body)
@@ -111,4 +111,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/channel_points_redemption/redemption_event.go
+++ b/internal/events/types/channel_points_redemption/redemption_event.go
@@ -54,7 +54,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -124,4 +124,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/channel_points_reward/reward_event.go
+++ b/internal/events/types/channel_points_reward/reward_event.go
@@ -47,7 +47,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -138,4 +138,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/cheer/cheer_event.go
+++ b/internal/events/types/cheer/cheer_event.go
@@ -45,7 +45,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -109,4 +109,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/drop/drop.go
+++ b/internal/events/types/drop/drop.go
@@ -44,7 +44,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					OrganizationID: params.FromUserID,
 				},
@@ -112,4 +112,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/extension_transaction/transaction_event.go
+++ b/internal/events/types/extension_transaction/transaction_event.go
@@ -56,7 +56,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					ExtensionClientID: clientID,
 				},
@@ -123,4 +123,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/follow/follow_event.go
+++ b/internal/events/types/follow/follow_event.go
@@ -35,7 +35,7 @@ func (e Event) GenerateEvent(p events.MockEventParameters) (events.MockEventResp
 				ID:      p.ID,
 				Status:  "enabled",
 				Type:    "channel.follow",
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: p.ToUserID,
 				},
@@ -96,4 +96,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/gift/channel_gift.go
+++ b/internal/events/types/gift/channel_gift.go
@@ -47,7 +47,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -113,4 +113,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/goal/goal_event.go
+++ b/internal/events/types/goal/goal_event.go
@@ -66,7 +66,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -134,4 +134,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/hype_train/hype_train_event.go
+++ b/internal/events/types/hype_train/hype_train_event.go
@@ -45,7 +45,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -142,4 +142,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/moderator_change/moderator_change_event.go
+++ b/internal/events/types/moderator_change/moderator_change_event.go
@@ -38,7 +38,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -98,4 +98,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/poll/poll.go
+++ b/internal/events/types/poll/poll.go
@@ -57,7 +57,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -137,4 +137,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/prediction/prediction.go
+++ b/internal/events/types/prediction/prediction.go
@@ -87,7 +87,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -162,4 +162,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/raid/raid.go
+++ b/internal/events/types/raid/raid.go
@@ -36,7 +36,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					ToBroadcasterUserID: params.ToUserID,
 				},
@@ -96,4 +96,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/stream_change/stream_change_event.go
+++ b/internal/events/types/stream_change/stream_change_event.go
@@ -50,7 +50,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    "channel.update",
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -112,4 +112,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/streamdown/streamdown.go
+++ b/internal/events/types/streamdown/streamdown.go
@@ -36,7 +36,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -92,4 +92,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/streamup/streamup.go
+++ b/internal/events/types/streamup/streamup.go
@@ -44,7 +44,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -103,4 +103,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/subscribe/sub_event.go
+++ b/internal/events/types/subscribe/sub_event.go
@@ -43,7 +43,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -106,4 +106,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/subscription_message/subscription_message.go
+++ b/internal/events/types/subscription_message/subscription_message.go
@@ -40,7 +40,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				ID:      params.ID,
 				Status:  "enabled",
 				Type:    triggerMapping[params.Transport][params.Trigger],
-				Version: "1",
+				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,
 				},
@@ -118,4 +118,8 @@ func (e Event) GetEventSubAlias(t string) string {
 		}
 	}
 	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }

--- a/internal/events/types/user/user_update.go
+++ b/internal/events/types/user/user_update.go
@@ -3,93 +3,97 @@
 package user_update
 
 import (
-    "encoding/json"
-    "time"
+	"encoding/json"
+	"time"
 
-    "github.com/twitchdev/twitch-cli/internal/events"
-    "github.com/twitchdev/twitch-cli/internal/models"
-    "github.com/twitchdev/twitch-cli/internal/util"
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
 )
 
 var transportsSupported = map[string]bool{
-    models.TransportEventSub: true,
+	models.TransportEventSub: true,
 }
 var triggers = []string{"user.update"}
 
 var triggerMapping = map[string]map[string]string{
-    models.TransportEventSub: {
-        "user.update": "user.update",
-    },
+	models.TransportEventSub: {
+		"user.update": "user.update",
+	},
 }
 
 type Event struct{}
 
 func (e Event) GenerateEvent(p events.MockEventParameters) (events.MockEventResponse, error) {
-    var event []byte
-    var err error
+	var event []byte
+	var err error
 
-    switch p.Transport {
-    case models.TransportEventSub:
-        body := models.EventsubResponse{
-            Subscription: models.EventsubSubscription{
-                ID:      p.ID,
-                Status:  "enabled",
-                Type:    "user.update",
-                Version: "1",
-                Condition: models.EventsubCondition{
-                    UserID : p.ToUserID,
-                },
-                Transport: models.EventsubTransport{
-                    Method:   "webhook",
-                    Callback: "null",
-                },
-                Cost:      0,
-                CreatedAt: util.GetTimestamp().Format(time.RFC3339Nano),
-            },
-            Event: models.UserUpdateEventSubEvent{
-                UserID:         p.ToUserID,
-                UserLogin:      p.ToUserName,
-                UserName:       p.ToUserName,
-                Description:    p.Description,
-            },
-        }
+	switch p.Transport {
+	case models.TransportEventSub:
+		body := models.EventsubResponse{
+			Subscription: models.EventsubSubscription{
+				ID:      p.ID,
+				Status:  "enabled",
+				Type:    "user.update",
+				Version: e.SubscriptionVersion(),
+				Condition: models.EventsubCondition{
+					UserID: p.ToUserID,
+				},
+				Transport: models.EventsubTransport{
+					Method:   "webhook",
+					Callback: "null",
+				},
+				Cost:      0,
+				CreatedAt: util.GetTimestamp().Format(time.RFC3339Nano),
+			},
+			Event: models.UserUpdateEventSubEvent{
+				UserID:      p.ToUserID,
+				UserLogin:   p.ToUserName,
+				UserName:    p.ToUserName,
+				Description: p.Description,
+			},
+		}
 
-        event, err = json.Marshal(body)
-        if err != nil {
-            return events.MockEventResponse{}, err
-        }
-    default:
-        return events.MockEventResponse{}, nil
-    }
+		event, err = json.Marshal(body)
+		if err != nil {
+			return events.MockEventResponse{}, err
+		}
+	default:
+		return events.MockEventResponse{}, nil
+	}
 
-    return events.MockEventResponse{
-        ID:             p.ID,
-        JSON:           event,
-        ToUser:         p.ToUserID,
-    }, nil
+	return events.MockEventResponse{
+		ID:     p.ID,
+		JSON:   event,
+		ToUser: p.ToUserID,
+	}, nil
 }
 
 func (e Event) ValidTransport(transport string) bool {
-    return transportsSupported[transport]
+	return transportsSupported[transport]
 }
 
 func (e Event) ValidTrigger(trigger string) bool {
-    for _, t := range triggers {
-        if t == trigger {
-            return true
-        }
-    }
-    return false
+	for _, t := range triggers {
+		if t == trigger {
+			return true
+		}
+	}
+	return false
 }
 func (e Event) GetTopic(transport string, trigger string) string {
-    return triggerMapping[transport][trigger]
+	return triggerMapping[transport][trigger]
 }
 func (e Event) GetEventSubAlias(t string) string {
-    // check for aliases
-    for trigger, topic := range triggerMapping[models.TransportEventSub] {
-        if topic == t {
-            return trigger
-        }
-    }
-    return ""
+	// check for aliases
+	for trigger, topic := range triggerMapping[models.TransportEventSub] {
+		if topic == t {
+			return trigger
+		}
+	}
+	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

The twitch docs state regarding `Twitch-Eventsub-Subscription-Version`:

> The version number that identifies the definition of the subscription request. This version matches the version number that you specified in your subscription request.

Currently, the CLI _always_ sends `test`. It should send the number included in the JSON payload.

## Description of Changes: 

- Expose `Event#SubscriptionVersion()`.
- Set `Twitch-Eventsub-Subscription-Version` to the event's subscription version.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
