### PR TITLE
fixing issue 172

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -119,7 +119,7 @@ func cmdRun(cmd *cobra.Command, args []string) {
 		body = getBodyFromFile(body[1:])
 	}
 
-	if cmd.PersistentFlags().Lookup("autopaginate").Changed {
+	if cmd.Name() == "get" && cmd.PersistentFlags().Lookup("autopaginate").Changed {
 		api.NewRequest(cmd.Name(), path, queryParameters, []byte(body), !prettyPrint, &autoPaginate)
 	} else {
 		api.NewRequest(cmd.Name(), path, queryParameters, []byte(body), !prettyPrint, nil) // only set on when the user changed the flag


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Fixes #172. 

## Description of Changes: 

- Adds a check to get the name of the command, since only "get" commands can use autopaginate flags. 
- This resolves a panic that was happening as a result of omitting that check

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
