### PR TITLE
support preflight request

### DIFF
--- a/internal/mock_api/endpoints/users/users.go
+++ b/internal/mock_api/endpoints/users/users.go
@@ -19,6 +19,7 @@ var userMethodsSupported = map[string]bool{
 	http.MethodDelete: false,
 	http.MethodPatch:  false,
 	http.MethodPut:    true,
+	"OPTIONS": true,
 }
 
 var userScopesByMethod = map[string][]string{
@@ -27,6 +28,7 @@ var userScopesByMethod = map[string][]string{
 	http.MethodDelete: {},
 	http.MethodPatch:  {},
 	http.MethodPut:    {"user:edit"},
+	"OPTIONS": {},
 }
 
 type User struct {
@@ -61,6 +63,8 @@ func (e UsersEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodGet:
+		getUsers(w, r)
+	case "OPTIONS":
 		getUsers(w, r)
 	case http.MethodPut:
 		putUsers(w, r)

--- a/internal/mock_api/mock_server/server.go
+++ b/internal/mock_api/mock_server/server.go
@@ -100,8 +100,15 @@ func RegisterHandlers(m *http.ServeMux) {
 func loggerMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("%v %v", r.Method, r.URL.Path)
+
+		w.Header().Set("Access-Control-Allow-Headers", "*")
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(200)
+			return
+		}
 
 		next.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature
When a Get request was made from the front end to the /users endpoint, a Preflight request was executed for CORS. However, the request to the endpoint was rejected because the server does not support the OPTIONS method and the Preflight request.

## Description of Changes: 
Changed CORS settings to allow the OPTIONS method in preflight requests. We also added and enabled the OPTIONS method in the /users endpoint to support the OPTIONS method.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [ ] I have updated the documentation (if applicable)
