### PR TITLE
EventSocket SSL Fix

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -35,6 +35,7 @@ var (
 	gameID           string
 	debug            bool
 	wssReconnectTest int
+	sslEnabled       bool
 )
 
 var eventCmd = &cobra.Command{
@@ -127,6 +128,7 @@ func init() {
 	// start-websocket-server flags
 	startWebsocketServerCmd.Flags().IntVarP(&port, "port", "p", 8080, "Defines the port that the mock EventSub websocket server will run on.")
 	startWebsocketServerCmd.Flags().BoolVar(&debug, "debug", false, "Set on/off for debug messages for the EventSub WebSocket server.")
+	startWebsocketServerCmd.Flags().BoolVar(&sslEnabled, "ssl", false, "Sets on/off for SSL. Recommended to keep 'false', as most testing does not require this.")
 	// TODO: This next flag is temporary, until I create a better way to test reconnecting.
 	startWebsocketServerCmd.Flags().IntVarP(&wssReconnectTest, "reconnect", "r", 0, "Used to test WebSocket Reconnect message. Sets delay (in seconds) from startup until the reconnect occurs.")
 }
@@ -245,6 +247,11 @@ func verifyCmdRun(cmd *cobra.Command, args []string) {
 }
 
 func startWebsocketServerCmdRun(cmd *cobra.Command, args []string) {
-	log.Printf("Starting mock EventSub WebSocket servers on wss://localhost:%v and wss://localhost:%v", port, port+1)
-	mock_wss_server.StartServer(port, debug, wssReconnectTest)
+	wsStr := "ws"
+	if sslEnabled {
+		wsStr = "wss"
+	}
+
+	log.Printf("Starting mock EventSub WebSocket servers on %v://localhost:%v and %v://localhost:%v", wsStr, port, wsStr, port+1)
+	mock_wss_server.StartServer(port, debug, wssReconnectTest, sslEnabled)
 }

--- a/internal/events/mock_wss_server/message_types.go
+++ b/internal/events/mock_wss_server/message_types.go
@@ -79,3 +79,21 @@ type ReconnectMessagePayloadSession struct { // <3>
 	ReconnectUrl                   string `json:"reconnect_url"`
 	ConnectedAt                    string `json:"connected_at"`
 }
+
+/* ** Keepalive message **
+{ // <1>
+    "metadata": { // <MessageMetadata>
+        "message_id": "84c1e79a-2a4b-4c13-ba0b-4312293e9308",
+        "message_type": "session_keepalive",
+        "message_timestamp": "2019-11-16T10:11:12.123Z"
+    },
+    "payload": {} // struct{}
+}
+*/
+
+type KeepaliveMessage struct { // <1>
+	Metadata MessageMetadata         `json:"metadata"`
+	Payload  KeepaliveMessagePayload `json:"payload"`
+}
+
+type KeepaliveMessagePayload struct{}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

EventSocket support used SSL by default, and didn't support ping/pong and keepalive. This PR solves those issues.

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
