### PR TITLE
Eventsocket small fixes

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -84,10 +84,11 @@ var retriggerCmd = &cobra.Command{
 
 var startWebsocketServerCmd = &cobra.Command{
 	Use:     "start-websocket-server",
-	Short:   "Starts a local websocket server at wss://localhost:8000",
+	Short:   `Starts a local websocket server at "ws://localhost:8080/eventsub" or at another preferred port.`,
 	Run:     startWebsocketServerCmdRun,
 	Example: `twitch event start-websocket-server`,
 	Aliases: []string{
+		"ws",
 		"wss",
 	},
 }
@@ -136,8 +137,7 @@ func init() {
 	startWebsocketServerCmd.Flags().IntVarP(&port, "port", "p", 8080, "Defines the port that the mock EventSub websocket server will run on.")
 	startWebsocketServerCmd.Flags().BoolVar(&debug, "debug", false, "Set on/off for debug messages for the EventSub WebSocket server.")
 	startWebsocketServerCmd.Flags().BoolVar(&sslEnabled, "ssl", false, "Sets on/off for SSL. Recommended to keep 'false', as most testing does not require this.")
-	// TODO: This next flag is temporary, until I create a better way to test reconnecting.
-	startWebsocketServerCmd.Flags().IntVarP(&wssReconnectTest, "reconnect", "r", 0, "Used to test WebSocket Reconnect message. Sets delay (in seconds) from startup until the reconnect occurs.")
+	startWebsocketServerCmd.Flags().IntVarP(&wssReconnectTest, "reconnect", "r", 0, "Used to test WebSocket Reconnect message. Sets delay (in seconds) from first client connection until the reconnect occurs.")
 }
 
 func triggerCmdRun(cmd *cobra.Command, args []string) {
@@ -263,6 +263,6 @@ func startWebsocketServerCmdRun(cmd *cobra.Command, args []string) {
 		wsStr = "wss"
 	}
 
-	log.Printf("Starting mock EventSub WebSocket servers on %v://localhost:%v and %v://localhost:%v", wsStr, port, wsStr, port+1)
+	log.Printf("Starting mock EventSub WebSocket servers on %v://localhost:%v/eventsub (alternate on port %v)", wsStr, port, port+1)
 	mock_wss_server.StartServer(port, debug, wssReconnectTest, sslEnabled)
 }

--- a/cmd/events.go
+++ b/cmd/events.go
@@ -264,5 +264,6 @@ func startWebsocketServerCmdRun(cmd *cobra.Command, args []string) {
 	}
 
 	log.Printf("Starting mock EventSub WebSocket servers on %v://localhost:%v/eventsub (alternate on port %v)", wsStr, port, port+1)
+	log.Printf("`Ctrl + C` to exit mock servers.")
 	mock_wss_server.StartServer(port, debug, wssReconnectTest, sslEnabled)
 }

--- a/cmd/events.go
+++ b/cmd/events.go
@@ -137,7 +137,7 @@ func init() {
 	startWebsocketServerCmd.Flags().IntVarP(&port, "port", "p", 8080, "Defines the port that the mock EventSub websocket server will run on.")
 	startWebsocketServerCmd.Flags().BoolVar(&debug, "debug", false, "Set on/off for debug messages for the EventSub WebSocket server.")
 	startWebsocketServerCmd.Flags().BoolVar(&sslEnabled, "ssl", false, "Sets on/off for SSL. Recommended to keep 'false', as most testing does not require this.")
-	startWebsocketServerCmd.Flags().IntVarP(&wssReconnectTest, "reconnect", "r", 0, "Used to test WebSocket Reconnect message. Sets delay (in seconds) from first client connection until the reconnect occurs.")
+	startWebsocketServerCmd.Flags().IntVarP(&wssReconnectTest, "reconnect", "r", -1, "Used to test WebSocket Reconnect message. Sets delay (in seconds) from first client connection until the reconnect occurs.")
 }
 
 func triggerCmdRun(cmd *cobra.Command, args []string) {

--- a/internal/events/mock_wss_server/message_types.go
+++ b/internal/events/mock_wss_server/message_types.go
@@ -19,7 +19,7 @@ type MessageMetadata struct {
 		"session": { // <3>
 			"id": "AQoQexAWVYKSTIu4ec_2VAxyuhAB",
 			"status": "connected",
-			"minimum_message_frequency_seconds": 10,
+			"keepalive_timeout_seconds": 10,
 			"reconnect_url": null,
 			"connected_at": "2019-11-16T10:11:12.123Z"
 		}
@@ -37,11 +37,11 @@ type WelcomeMessagePayload struct { // <2>
 }
 
 type WelcomeMessagePayloadSession struct { // <3>
-	ID                             string  `json:"id"`
-	Status                         string  `json:"status"`
-	MinimumMessageFrequencySeconds int     `json:"minimum_message_frequency_seconds"`
-	ReconnectUrl                   *string `json:"reconnect_url"`
-	ConnectedAt                    string  `json:"connected_at"`
+	ID                      string  `json:"id"`
+	Status                  string  `json:"status"`
+	KeepaliveTimeoutSeconds int     `json:"keepalive_timeout_seconds"`
+	ReconnectUrl            *string `json:"reconnect_url"`
+	ConnectedAt             string  `json:"connected_at"`
 }
 
 /* ** Reconnect message **
@@ -55,7 +55,7 @@ type WelcomeMessagePayloadSession struct { // <3>
 		"session": { // <3>
 			"id": "AQoQexAWVYKSTIu4ec_2VAxyuhAB",
 			"status": "reconnecting",
-			"minimum_message_frequency_seconds": null,
+			"keepalive_timeout_seconds": null,
 			"reconnect_url": "wss://eventsub-experimental.wss.twitch.tv?...",
 			"connected_at": "2019-11-16T10:11:12.123Z"
 		}
@@ -73,11 +73,11 @@ type ReconnectMessagePayload struct { // <2>
 }
 
 type ReconnectMessagePayloadSession struct { // <3>
-	ID                             string `json:"id"`
-	Status                         string `json:"status"`
-	MinimumMessageFrequencySeconds *int   `json:"minimum_message_frequency_seconds"`
-	ReconnectUrl                   string `json:"reconnect_url"`
-	ConnectedAt                    string `json:"connected_at"`
+	ID                      string `json:"id"`
+	Status                  string `json:"status"`
+	KeepaliveTimeoutSeconds *int   `json:"keepalive_timeout_seconds"`
+	ReconnectUrl            string `json:"reconnect_url"`
+	ConnectedAt             string `json:"connected_at"`
 }
 
 /* ** Keepalive message **

--- a/internal/events/mock_wss_server/server.go
+++ b/internal/events/mock_wss_server/server.go
@@ -91,7 +91,7 @@ func eventsubHandle(w http.ResponseWriter, r *http.Request) {
 				log.Printf("First client connected; Reconnect testing enabled. Notices will be sent in %d seconds.", wsSrv.reconnectTestTimeout)
 				duration := time.Second * time.Duration(wsSrv.reconnectTestTimeout)
 				if duration == 0 {
-					duration = time.Millisecond * 200
+					duration = time.Second * 1
 				}
 
 				select {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Minor fixes to make websocket reconnect testing work correctly.

## Description of Changes: 

- Fixed help message inconsistency
- Corrected incorrect console messages in reconnect testing
- Changed default -r/--reconnect value to websocket reconnect testing to -1, as to allow for "-r 0"
- Added note in console on how to exit mock websocket server using ctrl + c
- Updated "minimum_message_frequency_seconds" field to "keepalive_timeout_seconds"

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
