### PR TITLE
Fix Chairty to use the correct type when building a payload.

### DIFF
--- a/internal/events/types/charity/charity_event.go
+++ b/internal/events/types/charity/charity_event.go
@@ -137,7 +137,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 		body := models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
 				ID:      params.ID,
-				Type:    "channel.charity_campaign.donate",
+				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
 				Status:  params.SubscriptionStatus,
 				Cost:    0,


### PR DESCRIPTION
Using goal/goal_event as a basis for the "find the type to use"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

The four chairty topics were all morphing the payload but using a hard coded type

## Description of Changes: 

Fix type in chairty to use type for the matrix not _always_ `.donate`

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
