### PR TITLE
Eventsub type consistency

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -124,7 +124,7 @@ func init() {
 	triggerCmd.Flags().StringVarP(&eventID, "subscription-id", "u", "", "Manually set the subscription/event ID of the event itself.") // TODO: This description will need to change with https://github.com/twitchdev/twitch-cli/issues/184
 	triggerCmd.Flags().StringVar(&timestamp, "timestamp", "", "Sets the timestamp to be used in payloads and headers. Must be in RFC3339Nano format.")
 	triggerCmd.Flags().IntVar(&charityCurrentValue, "charity-current-value", 0, "Only used for \"charity-*\" events. Manually set the current dollar value for charity events.")
-	triggerCmd.Flags().IntVar(&charityTargetValue, "charity-target-value", 1500000, "Only used for \"charity-*\" events. Manually set the current dollar value for charity events")
+	triggerCmd.Flags().IntVar(&charityTargetValue, "charity-target-value", 1500000, "Only used for \"charity-*\" events. Manually set the target dollar value for charity events.")
 
 	// retrigger flags
 	retriggerCmd.Flags().StringVarP(&forwardAddress, "forward-address", "F", "", "Forward address for mock event.")

--- a/internal/events/types/follow/follow_event.go
+++ b/internal/events/types/follow/follow_event.go
@@ -33,7 +33,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 			Subscription: models.EventsubSubscription{
 				ID:      params.ID,
 				Status:  params.SubscriptionStatus,
-				Type:    "channel.follow",
+				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,

--- a/internal/events/types/stream_change/stream_change_event.go
+++ b/internal/events/types/stream_change/stream_change_event.go
@@ -47,7 +47,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 			Subscription: models.EventsubSubscription{
 				ID:      params.ID,
 				Status:  params.SubscriptionStatus,
-				Type:    "channel.update",
+				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					BroadcasterUserID: params.ToUserID,

--- a/internal/events/types/user/user_update.go
+++ b/internal/events/types/user/user_update.go
@@ -33,7 +33,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 			Subscription: models.EventsubSubscription{
 				ID:      params.ID,
 				Status:  params.SubscriptionStatus,
-				Type:    "user.update",
+				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
 				Condition: models.EventsubCondition{
 					UserID: params.ToUserID,


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Changes all EventSub event code files change their Subscription.Type value to grab programatically instead of being a hardcoded string.
This will avoid any copy/paste issues that arise and get missed, as seen in #201

## Description of Changes: 

- Made change as described above
- Fixed typo in description of --charity-target-value flag

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
