### PR TITLE
Add subscription tier flag

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -36,6 +36,7 @@ var (
 	count               int
 	description         string
 	gameID              string
+	tier                string
 	timestamp           string
 	charityCurrentValue int
 	charityTargetValue  int
@@ -121,6 +122,7 @@ func init() {
 	triggerCmd.Flags().Int64VarP(&cost, "cost", "C", 0, "Amount of bits or channel points redeemed/used in the event.")
 	triggerCmd.Flags().StringVarP(&description, "description", "d", "", "Title the stream should be updated with.")
 	triggerCmd.Flags().StringVarP(&gameID, "game-id", "G", "", "Sets the game/category ID for applicable events.")
+	triggerCmd.Flags().StringVarP(&tier, "tier", "", "", "Sets the subscription tier. Valid values are 1000, 2000, and 3000.")
 	triggerCmd.Flags().StringVarP(&eventID, "subscription-id", "u", "", "Manually set the subscription/event ID of the event itself.") // TODO: This description will need to change with https://github.com/twitchdev/twitch-cli/issues/184
 	triggerCmd.Flags().StringVar(&timestamp, "timestamp", "", "Sets the timestamp to be used in payloads and headers. Must be in RFC3339Nano format.")
 	triggerCmd.Flags().IntVar(&charityCurrentValue, "charity-current-value", 0, "Only used for \"charity-*\" events. Manually set the current dollar value for charity events.")
@@ -189,6 +191,7 @@ func triggerCmdRun(cmd *cobra.Command, args []string) {
 			Description:         description,
 			ItemName:            itemName,
 			GameID:              gameID,
+			Tier:                tier,
 			SubscriptionStatus:  subscriptionStatus,
 			Timestamp:           timestamp,
 			CharityCurrentValue: charityCurrentValue,

--- a/docs/event.md
+++ b/docs/event.md
@@ -77,6 +77,7 @@ Used to either create or send mock events for use with local webhooks testing.
 | `--cost`            | `-C`      | Amount of bits or channel points redeemed/used in the event.                                                                                                  | `-C 250`                                  | N               |
 | `--description`     | `-d`      | Title the stream should be updated/started with.                                                                                                              | `-d Awesome new title!`                   | N               |
 | `--game-id`         | `-G`      | Game ID for Drop or other relevant events.                                                                                                                    | `-G 1234`                                 | N               |
+| `--tier`            |           | Tier of the subscription.              | `--tier 3000` | N          |
 
 
 ```sh

--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -22,6 +22,7 @@ type MockEventParameters struct {
 	IsPermanent         bool
 	Description         string
 	GameID              string
+	Tier                string
 	Timestamp           string
 	CharityCurrentValue int
 	CharityTargetValue  int

--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -35,6 +35,7 @@ type TriggerParameters struct {
 	Description         string
 	ItemName            string
 	GameID              string
+	Tier                string
 	Timestamp           string
 	EventID             string // Also serves as subscription ID. See https://github.com/twitchdev/twitch-cli/issues/184
 	CharityCurrentValue int
@@ -64,6 +65,17 @@ func Fire(p TriggerParameters) (string, error) {
 
 	if p.GameID == "" {
 		p.GameID = fmt.Sprint(util.RandomInt(10 * 1000))
+	}
+
+	switch p.Tier {
+	case "":
+		p.Tier = "1000"
+	case "1000", "2000", "3000":
+		// do nothing, these are valid values
+	default:
+		return "", fmt.Errorf(
+			`Discarding event: Invalid tier provided.
+	Valid values are 1000, 2000 or 3000`)
 	}
 
 	if p.EventID == "" {
@@ -98,6 +110,7 @@ https://dev.twitch.tv/docs/eventsub/handling-webhook-events#processing-an-event`
 		Description:         p.Description,
 		ItemName:            p.ItemName,
 		GameID:              p.GameID,
+		Tier:                p.Tier,
 		SubscriptionStatus:  p.SubscriptionStatus,
 		Timestamp:           p.Timestamp,
 		CharityCurrentValue: p.CharityCurrentValue,

--- a/internal/events/types/subscribe/sub_event.go
+++ b/internal/events/types/subscribe/sub_event.go
@@ -60,7 +60,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				BroadcasterUserID:    params.ToUserID,
 				BroadcasterUserLogin: params.ToUserName,
 				BroadcasterUserName:  params.ToUserName,
-				Tier:                 "1000",
+				Tier:                 params.Tier,
 				IsGift:               params.IsGift,
 			},
 		}

--- a/internal/events/types/subscribe/sub_event_test.go
+++ b/internal/events/types/subscribe/sub_event_test.go
@@ -13,6 +13,7 @@ import (
 
 var fromUser = "1234"
 var toUser = "4567"
+var tierTwo = "2000"
 
 func TestEventSub(t *testing.T) {
 	a := test_setup.SetupTestEnv(t)
@@ -23,6 +24,7 @@ func TestEventSub(t *testing.T) {
 		Transport:          models.TransportEventSub,
 		SubscriptionStatus: "enabled",
 		Trigger:            "subscribe",
+		Tier:               tierTwo,
 	}
 
 	r, err := Event{}.GenerateEvent(params)
@@ -34,6 +36,7 @@ func TestEventSub(t *testing.T) {
 
 	a.Equal(toUser, body.Event.BroadcasterUserID, "Expected to user %v, got %v", toUser, body.Event.BroadcasterUserID)
 	a.Equal(fromUser, body.Event.UserID, "Expected from user %v, got %v", r.ToUser, body.Event.UserID)
+	a.Equal(tierTwo, body.Event.Tier, "Expected tier %v, got %v", tierTwo, body.Event.Tier)
 }
 
 func TestFakeTransport(t *testing.T) {

--- a/internal/events/types/subscription_message/subscription_message.go
+++ b/internal/events/types/subscription_message/subscription_message.go
@@ -58,7 +58,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				BroadcasterUserID:    params.ToUserID,
 				BroadcasterUserLogin: params.ToUserName,
 				BroadcasterUserName:  params.ToUserName,
-				Tier:                 "1000",
+				Tier:                 params.Tier,
 				Message: models.SubscribeMessageEventSubMessage{
 					Text: "Hello from the Twitch CLI! twitchdevLeek",
 					Emotes: []models.SubscribeMessageEventSubMessageEmote{

--- a/internal/events/types/subscription_message/subscription_message_test.go
+++ b/internal/events/types/subscription_message/subscription_message_test.go
@@ -17,6 +17,7 @@ var toUser = "4567"
 func TestEventSub(t *testing.T) {
 	a := test_setup.SetupTestEnv(t)
 	ten := 10
+	tierThree := "3000"
 
 	params := *&events.MockEventParameters{
 		FromUserID:         fromUser,
@@ -44,6 +45,7 @@ func TestEventSub(t *testing.T) {
 		SubscriptionStatus: "enabled",
 		Cost:               int64(ten),
 		IsAnonymous:        true,
+		Tier:               tierThree,
 	}
 
 	r, err = Event{}.GenerateEvent(params)
@@ -53,6 +55,7 @@ func TestEventSub(t *testing.T) {
 	a.Nil(err)
 	a.Nil(body.Event.StreakMonths)
 	a.GreaterOrEqual(body.Event.CumulativeMonths, 10)
+	a.Equal(body.Event.Tier, "3000")
 }
 
 func TestFakeTransport(t *testing.T) {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

This PR adds the `tier` flag so that the users can specify the tier at which subscription events happen (1000, 2000 or 3000)

## Description of Changes: 

- Added the new `tier` flag which accepts either 1000, 2000, or 3000.
- If the tier flag is not passed, the default continues to be 1000.
- No short form was added to this flag as `T` and `t` are already being used.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
