### PR TITLE
Added SSL support for the EventSub WebSocket server

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -45,8 +45,6 @@ var (
 	clientId            string
 	version             string
 	websocketClient     string
-	websocketServerIP   string
-	websocketServerPort int
 )
 
 // websocketCmd-specific flags
@@ -57,6 +55,9 @@ var (
 	wsSubscription string
 	wsStatus       string
 	wsReason       string
+	wsServerIP     string
+	wsServerPort   int
+	wsSSL          bool
 )
 
 var eventCmd = &cobra.Command{
@@ -175,8 +176,9 @@ func init() {
 
 	// websocket flags
 	/// flags for start-server
-	websocketCmd.Flags().StringVar(&websocketServerIP, "ip", "127.0.0.1", "Defines the ip that the mock EventSub websocket server will bind to.")
-	websocketCmd.Flags().IntVarP(&websocketServerPort, "port", "p", 8080, "Defines the port that the mock EventSub websocket server will run on.")
+	websocketCmd.Flags().StringVar(&wsServerIP, "ip", "127.0.0.1", "Defines the ip that the mock EventSub websocket server will bind to.")
+	websocketCmd.Flags().IntVarP(&wsServerPort, "port", "p", 8080, "Defines the port that the mock EventSub websocket server will run on.")
+	websocketCmd.Flags().BoolVar(&wsSSL, "ssl", false, "Enables SSL for EventSub websocket server (wss) and EventSub mock subscription server (https).")
 	websocketCmd.Flags().BoolVar(&wsDebug, "debug", false, "Set on/off for debug messages for the EventSub WebSocket server.")
 	websocketCmd.Flags().BoolVarP(&wsStrict, "require-subscription", "S", false, "Requires subscriptions for all events, and activates 10 second subscription requirement.")
 
@@ -334,8 +336,9 @@ func websocketCmdRun(cmd *cobra.Command, args []string) {
 	}
 
 	if args[0] == "start-server" || args[0] == "start" {
+		log.Printf("Attempting to start WebSocket server on %v:%v", wsServerIP, wsServerPort)
 		log.Printf("`Ctrl + C` to exit mock WebSocket servers.")
-		mock_server.StartWebsocketServer(wsDebug, websocketServerIP, websocketServerPort, wsStrict)
+		mock_server.StartWebsocketServer(wsDebug, wsServerIP, wsServerPort, wsSSL, wsStrict)
 	} else {
 		// Forward all other commands via RPC
 		websocket.ForwardWebsocketCommand(args[0], websocket.WebsocketCommandParameters{

--- a/internal/events/websocket/mock_server/rpc_handler.go
+++ b/internal/events/websocket/mock_server/rpc_handler.go
@@ -215,7 +215,7 @@ func RPCSubscriptionHandler(args rpc.RPCArgs) rpc.RPCResponse {
 		return rpc.RPCResponse{
 			ResponseCode: COMMAND_RESPONSE_MISSING_FLAG,
 			DetailedInfo: "Command \"subscription\" requires flags --status, --subscription, and --session" +
-				fmt.Sprintf("\nThe flag --subscription must be the ID of the subscription made at http://%v:%v/eventsub/subscriptions", serverManager.ip, serverManager.port) +
+				fmt.Sprintf("\nThe flag --subscription must be the ID of the subscription made at %v://%v:%v/eventsub/subscriptions", serverManager.protocolHttp, serverManager.ip, serverManager.port) +
 				"\nThe flag --status must be one of the non-webhook status options defined here:" +
 				"\nhttps://dev.twitch.tv/docs/api/reference/#get-eventsub-subscriptions" +
 				"\n\nExample: twitch event websocket subscription --status=user_removed --subscription=82a855-fae8-93bff0",

--- a/internal/events/websocket/mock_server/server.go
+++ b/internal/events/websocket/mock_server/server.go
@@ -59,7 +59,7 @@ func (ws *WebSocketServer) WsPageHandler(w http.ResponseWriter, r *http.Request)
 		clientName:           util.RandomGUID()[:8],
 		conn:                 conn,
 		ConnectedAtTimestamp: connectedAtTimestamp,
-		connectionUrl:        fmt.Sprintf("http://%v/ws", r.Host),
+		connectionUrl:        fmt.Sprintf("%v://%v/ws", serverManager.protocolHttp, r.Host),
 		keepAliveChanOpen:    false,
 		pingChanOpen:         false,
 	}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

There was no SSL support for EventSub WebSocket servers.

## Description of Changes: 

- Added --ssl flag for 'twitch event websocket start'
- Fixed welcome message for websocket server appearing even when server fails to start

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
