### PR TITLE
fix: match name to documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Suggest a new idea for the twitch-cli.
+description: Suggest a new idea for the Twitch CLI.
 title: "[Feature Request] "
 labels: ["enhancement"]
 body:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

I missed a line and left twitch-cli.

## Description of Changes: 

- Twitch CLI as that's consistent with the branding on the documentation.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
