### PR TITLE
Fix typo in an error and a migration message

### DIFF
--- a/internal/database/init.go
+++ b/internal/database/init.go
@@ -41,7 +41,7 @@ CREATE TABLE chat_settings( broadcaster_id text not null primary key, slow_mode 
 INSERT INTO chat_settings (broadcaster_id) SELECT id FROM users;
 ALTER TABLE users ADD COLUMN chat_color text not null default '#9146FF';
 CREATE TABLE vips ( broadcaster_id text not null, user_id text not null, created_at text not null default '', primary key (broadcaster_id, user_id), foreign key (broadcaster_id) references users(id), foreign key (user_id) references users(id) );`,
-		Message: `Updating database to include API changes since last verison. See Twitch CLI changelog for more info.`,
+		Message: `Updating database to include API changes since last version. See Twitch CLI changelog for more info.`,
 	},
 }
 

--- a/internal/events/types/types.go
+++ b/internal/events/types/types.go
@@ -132,11 +132,11 @@ func GetByTriggerAndTransportAndVersion(trigger string, transport string, versio
 		return latestEventSeen, nil
 	}
 
-	// Error for events with non-existent verison used
+	// Error for events with non-existent version used
 	if len(validEventBadVersions) != 0 {
 		errStr := fmt.Sprintf("Invalid version given. Valid version(s): %v", strings.Join(validEventBadVersions, ", "))
 		if version == "" {
-			errStr += "\nUse --verison to specify"
+			errStr += "\nUse --version to specify"
 		}
 		return nil, errors.New(errStr)
 	}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Couple of small typos in an error string and a migration message.

## Description of Changes: 

- Changed `verison` to `version` in both the error and migration message

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
