### PR TITLE
Fixed issue with retrigger events when events have multiple versions

### DIFF
--- a/internal/events/trigger/retrigger_event.go
+++ b/internal/events/trigger/retrigger_event.go
@@ -23,13 +23,13 @@ func RefireEvent(id string, p TriggerParameters) (string, error) {
 
 	p.Transport = res.Transport
 
-	var previousEventObj models.EventsubSubscription
+	var previousEventObj models.EventsubResponse
 	err = json.Unmarshal([]byte(res.JSON), &previousEventObj)
 	if err != nil {
 		return "", fmt.Errorf("Unable to parse previous event's JSON from database: %v", err.Error())
 	}
 
-	e, err := types.GetByTriggerAndTransportAndVersion(res.Event, p.Transport, previousEventObj.Version)
+	e, err := types.GetByTriggerAndTransportAndVersion(res.Event, p.Transport, previousEventObj.Subscription.Version)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

There was an issue with `twitch retrigger` where channel.follow didn't work due to its multiple versions. The wrong object type was being used when unmarshaling the JSON, which didn't throw an error but didn't fill in any data. This wasn't noticed because the only time that object is used for refiring the event is when grabbing the subscription version, but for subscriptions with only one version available the subscription version can be empty and it'll default to the only one available.

## Description of Changes: 

- Fixed bug where `twitch retrigger` doesn't work for channel.follow due to having multiple versions

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
