### PR TITLE
Incorrect return value for channel.prediction.lock

### DIFF
--- a/internal/events/types/prediction/prediction.go
+++ b/internal/events/types/prediction/prediction.go
@@ -72,7 +72,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 						ChannelPointsUsed: int(util.RandomInt(10*1000)) + 100,
 					}
 					sum += t.ChannelPointsUsed
-					if params.Trigger == "prediction-lock" || params.Trigger == "prediction-end" {
+					if params.Trigger == "prediction-end" {
 						if i == 0 {
 							t.ChannelPointsWon = intPointer(t.ChannelPointsUsed * 2)
 						} else {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Fixes #241 

## Description of Changes: 

- Fixed `channel_points_won` field to now show null on `channel.prediction.progress` and `channel.prediction.lock`

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
