### PR TITLE
--config flag not working

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,8 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	cfgFile, err := util.GetConfigPath()
+	var err error
+	cfgFile, err = util.GetConfigPath()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Fixes #249

## Description of Changes: 

- Config file variable was being overwritten by local variable and not persisting globally, causing the `--config` flag to not work at all.

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
