### PR TITLE
GET Drops Entitlements "mock-API" - Enabled filter by status

### DIFF
--- a/internal/mock_api/endpoints/drops/entitlements.go
+++ b/internal/mock_api/endpoints/drops/entitlements.go
@@ -70,6 +70,7 @@ func getEntitlements(w http.ResponseWriter, r *http.Request) {
 	id := r.URL.Query().Get("id")
 	userID := r.URL.Query().Get("user_id")
 	gameID := r.URL.Query().Get("game_id")
+	status := r.URL.Query().Get("fulfillment_status")
 
 	if userCtx.UserID != "" && userID != "" {
 		mock_errors.WriteBadRequest(w, "user_id is invalid when using user access token")
@@ -78,7 +79,7 @@ func getEntitlements(w http.ResponseWriter, r *http.Request) {
 	if userCtx.UserID != "" {
 		userID = userCtx.UserID
 	}
-	e := database.DropsEntitlement{UserID: userID, GameID: gameID, ID: id}
+	e := database.DropsEntitlement{UserID: userID, GameID: gameID, ID: id, Status: status}
 	dbr, err := db.NewQuery(r, 1000).GetDropsEntitlements(e)
 	if err != nil {
 		mock_errors.WriteServerError(w, "error fetching entitlements")


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

As explained in the [official documentation](https://dev.twitch.tv/docs/api/reference/#get-drops-entitlements) for the GET Drops Entitlements API, _fulfillment_status_ is one of the possible query parameter that the API is accepting. 
Until now, this parameter was ignored in the _mock-api_. This PR aims to fix this, so now the _mock-api_ supports filtering by _fulfillment_status_.

## Description of Changes: 

- Read the "fulfillment_status" optional query parameter from the URL
- Use this new field as a value to the DropsEntitlement object used for the DB query

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
