### PR TITLE
Content Classification Label updates

### DIFF
--- a/internal/database/user.go
+++ b/internal/database/user.go
@@ -13,24 +13,28 @@ import (
 )
 
 type User struct {
-	ID              string         `db:"id" json:"id" dbs:"u1.id"`
-	UserLogin       string         `db:"user_login" json:"login"`
-	DisplayName     string         `db:"display_name" json:"display_name"`
-	Email           string         `db:"email" json:"email,omitempty"`
-	UserType        string         `db:"user_type" json:"type"`
-	BroadcasterType string         `db:"broadcaster_type" json:"broadcaster_type"`
-	UserDescription string         `db:"user_description" json:"description"`
-	CreatedAt       string         `db:"created_at" json:"created_at"`
-	ModifiedAt      string         `db:"modified_at" json:"-"`
-	ProfileImageURL string         `dbi:"false" json:"profile_image_url" `
-	OfflineImageURL string         `dbi:"false" json:"offline_image_url" `
-	ViewCount       int            `dbi:"false" json:"view_count"`
-	CategoryID      sql.NullString `db:"category_id" json:"game_id" dbi:"force"`
-	CategoryName    sql.NullString `db:"category_name" json:"game_name" dbi:"false"`
-	Title           string         `db:"title" json:"title"`
-	Language        string         `db:"stream_language" json:"stream_language"`
-	Delay           int            `db:"delay" json:"delay" dbi:"force"`
-	ChatColor       string         `db:"chat_color" json:"-"`
+	ID               string         `db:"id" json:"id" dbs:"u1.id"`
+	UserLogin        string         `db:"user_login" json:"login"`
+	DisplayName      string         `db:"display_name" json:"display_name"`
+	Email            string         `db:"email" json:"email,omitempty"`
+	UserType         string         `db:"user_type" json:"type"`
+	BroadcasterType  string         `db:"broadcaster_type" json:"broadcaster_type"`
+	UserDescription  string         `db:"user_description" json:"description"`
+	CreatedAt        string         `db:"created_at" json:"created_at"`
+	ModifiedAt       string         `db:"modified_at" json:"-"`
+	ProfileImageURL  string         `dbi:"false" json:"profile_image_url" `
+	OfflineImageURL  string         `dbi:"false" json:"offline_image_url" `
+	ViewCount        int            `dbi:"false" json:"view_count"`
+	CategoryID       sql.NullString `db:"category_id" json:"game_id" dbi:"force"`
+	CategoryName     sql.NullString `db:"category_name" json:"game_name" dbi:"false"`
+	Title            string         `db:"title" json:"title"`
+	Language         string         `db:"stream_language" json:"stream_language"`
+	Delay            int            `db:"delay" json:"delay" dbi:"force"`
+	ChatColor        string         `db:"chat_color" json:"-"`
+	IsBrandedContent bool           `db:"branded_content" json:"is_branded_content"`
+
+	// UnparsedCCLs is a comma seperated array (e.g. "Gambling,ViolentGraphic,ProfanityVulgarity")
+	UnparsedCCLs string `db:"content_labels" json:"-"`
 }
 
 type Follow struct {

--- a/internal/events/types/channel_update_v1/channel_update.go
+++ b/internal/events/types/channel_update_v1/channel_update.go
@@ -1,0 +1,149 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package channel_update_v1
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+)
+
+var transportsSupported = map[string]bool{
+	models.TransportWebhook:   true,
+	models.TransportWebSocket: true,
+}
+
+var triggerSupported = []string{"stream-change"}
+
+var triggerMapping = map[string]map[string]string{
+	models.TransportWebhook: {
+		"stream-change": "channel.update",
+	},
+	models.TransportWebSocket: {
+		"stream-change": "channel.update",
+	},
+}
+
+type Event struct{}
+
+func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEventResponse, error) {
+	var event []byte
+	var err error
+
+	if params.Description == "" {
+		params.Description = "Example title from the CLI!"
+	}
+	if params.ItemID == "" && params.GameID == "" {
+		params.GameID = "509658"
+	} else if params.ItemID != "" && params.GameID == "" {
+		params.GameID = params.ItemID
+	}
+	if params.ItemName == "" {
+		params.ItemName = "Just Chatting"
+	}
+
+	switch params.Transport {
+	case models.TransportWebhook, models.TransportWebSocket:
+		body := &models.EventsubResponse{
+			// make the eventsub response (if supported)
+			Subscription: models.EventsubSubscription{
+				ID:      params.ID,
+				Status:  params.SubscriptionStatus,
+				Type:    triggerMapping[params.Transport][params.Trigger],
+				Version: e.SubscriptionVersion(),
+				Condition: models.EventsubCondition{
+					BroadcasterUserID: params.ToUserID,
+				},
+				Transport: models.EventsubTransport{
+					Method:   "webhook",
+					Callback: "null",
+				},
+				Cost:      0,
+				CreatedAt: params.Timestamp,
+			},
+			Event: models.ChannelUpdateEventSubEvent{
+				BroadcasterUserID:    params.ToUserID,
+				BroadcasterUserLogin: params.ToUserName,
+				BroadcasterUserName:  params.ToUserName,
+				StreamTitle:          params.Description,
+				StreamLanguage:       "en",
+				StreamCategoryID:     params.GameID,
+				StreamCategoryName:   params.ItemName,
+				IsMature:             falsePtr(),
+			},
+		}
+		event, err = json.Marshal(body)
+		if err != nil {
+			return events.MockEventResponse{}, err
+		}
+
+		// Delete event info if Subscription.Status is not set to "enabled"
+		if !strings.EqualFold(params.SubscriptionStatus, "enabled") {
+			var i interface{}
+			if err := json.Unmarshal([]byte(event), &i); err != nil {
+				return events.MockEventResponse{}, err
+			}
+			if m, ok := i.(map[string]interface{}); ok {
+				delete(m, "event") // Matches JSON key defined in body variable above
+			}
+
+			event, err = json.Marshal(i)
+			if err != nil {
+				return events.MockEventResponse{}, err
+			}
+		}
+	default:
+		return events.MockEventResponse{}, nil
+	}
+
+	return events.MockEventResponse{
+		ID:       params.ID,
+		JSON:     event,
+		FromUser: params.FromUserID,
+		ToUser:   params.ToUserID,
+	}, nil
+}
+
+func (e Event) ValidTransport(t string) bool {
+	return transportsSupported[t]
+}
+
+func (e Event) ValidTrigger(t string) bool {
+	for _, ts := range triggerSupported {
+		if ts == t {
+			return true
+		}
+	}
+	return false
+}
+
+func (e Event) GetTopic(transport string, trigger string) string {
+	return triggerMapping[transport][trigger]
+}
+func (e Event) GetAllTopicsByTransport(transport string) []string {
+	allTopics := []string{}
+	for _, topic := range triggerMapping[transport] {
+		allTopics = append(allTopics, topic)
+	}
+	return allTopics
+}
+func (e Event) GetEventSubAlias(t string) string {
+	// check for aliases
+	for trigger, topic := range triggerMapping[models.TransportWebhook] {
+		if topic == t {
+			return trigger
+		}
+	}
+	return ""
+}
+
+func (e Event) SubscriptionVersion() string {
+	return "1"
+}
+
+func falsePtr() *bool {
+	f := false
+	return &f
+}

--- a/internal/events/types/channel_update_v1/channel_update_test.go
+++ b/internal/events/types/channel_update_v1/channel_update_test.go
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package stream_change
+package channel_update_v1
 
 import (
 	"encoding/json"

--- a/internal/events/types/channel_update_v2/channel_update.go
+++ b/internal/events/types/channel_update_v2/channel_update.go
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package stream_change
+package channel_update_v2
 
 import (
 	"encoding/json"
@@ -71,7 +71,10 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				StreamLanguage:       "en",
 				StreamCategoryID:     params.GameID,
 				StreamCategoryName:   params.ItemName,
-				IsMature:             false,
+				ContentClassificationLabels: []string{
+					"MatureGame",
+					"ViolentGraphic",
+				},
 			},
 		}
 		event, err = json.Marshal(body)
@@ -140,5 +143,5 @@ func (e Event) GetEventSubAlias(t string) string {
 }
 
 func (e Event) SubscriptionVersion() string {
-	return "1"
+	return "beta"
 }

--- a/internal/events/types/channel_update_v2/channel_update_test.go
+++ b/internal/events/types/channel_update_v2/channel_update_test.go
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package channel_update_v2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/twitchdev/twitch-cli/internal/events"
+	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/test_setup"
+)
+
+var fromUser = "1234"
+var toUser = "4567"
+
+func TestEventSub(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	params := *&events.MockEventParameters{
+		FromUserID:         fromUser,
+		ToUserID:           toUser,
+		Transport:          models.TransportWebhook,
+		Trigger:            "stream-change",
+		SubscriptionStatus: "enabled",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	var body models.ChannelUpdateEventSubResponse
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err, "Error unmarshalling JSON")
+
+	// write actual tests here (making sure you set appropriate values and the like) for eventsub
+	a.Equal(toUser, body.Event.BroadcasterUserID, "Expected Stream Channel %v, got %v", toUser, body.Event.BroadcasterUserID)
+
+	// test for changing a title
+	params = events.MockEventParameters{
+		FromUserID:         fromUser,
+		ToUserID:           toUser,
+		Transport:          models.TransportWebhook,
+		Trigger:            "stream_change",
+		SubscriptionStatus: "enabled",
+		GameID:             "1234",
+	}
+
+	r, err = Event{}.GenerateEvent(params)
+	a.Nil(err)
+
+	err = json.Unmarshal(r.JSON, &body)
+	a.Nil(err)
+
+	a.Equal(toUser, body.Event.BroadcasterUserID, "Expected Stream Channel %v, got %v", toUser, body.Event.BroadcasterUserID)
+	a.Equal("Example title from the CLI!", body.Event.StreamTitle, "Expected new stream title, got %v", body.Event.StreamTitle)
+	a.Equal("1234", body.Event.StreamCategoryID)
+}
+
+func TestFakeTransport(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	params := events.MockEventParameters{
+		FromUserID:         fromUser,
+		ToUserID:           toUser,
+		Transport:          "fake_transport",
+		Trigger:            "stream-change",
+		SubscriptionStatus: "enabled",
+	}
+
+	r, err := Event{}.GenerateEvent(params)
+	a.Nil(err)
+	a.Empty(r)
+}
+func TestValidTrigger(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.ValidTrigger("stream-change")
+	a.Equal(true, r)
+
+	r = Event{}.ValidTrigger("not_trigger_keyword")
+	a.Equal(false, r)
+}
+
+func TestValidTransport(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.ValidTransport(models.TransportWebhook)
+	a.Equal(true, r)
+
+	r = Event{}.ValidTransport("noteventsub")
+	a.Equal(false, r)
+}
+func TestGetTopic(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+
+	r := Event{}.GetTopic(models.TransportWebhook, "stream-change")
+	a.NotNil(r)
+}

--- a/internal/events/types/types.go
+++ b/internal/events/types/types.go
@@ -14,6 +14,8 @@ import (
 	"github.com/twitchdev/twitch-cli/internal/events/types/ban"
 	"github.com/twitchdev/twitch-cli/internal/events/types/channel_points_redemption"
 	"github.com/twitchdev/twitch-cli/internal/events/types/channel_points_reward"
+	"github.com/twitchdev/twitch-cli/internal/events/types/channel_update_v1"
+	"github.com/twitchdev/twitch-cli/internal/events/types/channel_update_v2"
 	"github.com/twitchdev/twitch-cli/internal/events/types/charity"
 	"github.com/twitchdev/twitch-cli/internal/events/types/cheer"
 	"github.com/twitchdev/twitch-cli/internal/events/types/drop"
@@ -29,7 +31,6 @@ import (
 	"github.com/twitchdev/twitch-cli/internal/events/types/raid"
 	"github.com/twitchdev/twitch-cli/internal/events/types/shield_mode"
 	"github.com/twitchdev/twitch-cli/internal/events/types/shoutout"
-	"github.com/twitchdev/twitch-cli/internal/events/types/stream_change"
 	"github.com/twitchdev/twitch-cli/internal/events/types/streamdown"
 	"github.com/twitchdev/twitch-cli/internal/events/types/streamup"
 	"github.com/twitchdev/twitch-cli/internal/events/types/subscribe"
@@ -60,7 +61,8 @@ func AllEvents() []events.MockEvent {
 		raid.Event{},
 		shield_mode.Event{},
 		shoutout.Event{},
-		stream_change.Event{},
+		channel_update_v1.Event{},
+		channel_update_v2.Event{},
 		streamup.Event{},
 		streamdown.Event{},
 		subscribe.Event{},

--- a/internal/mock_api/endpoints/ccl/ccl_test.go
+++ b/internal/mock_api/endpoints/ccl/ccl_test.go
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package ccl
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/twitchdev/twitch-cli/test_setup"
+	"github.com/twitchdev/twitch-cli/test_setup/test_server"
+)
+
+func TestContentClassificationLabels(t *testing.T) {
+	a := test_setup.SetupTestEnv(t)
+	ts := test_server.SetupTestServer(ContentClassificationLabels{})
+
+	// get
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+ContentClassificationLabels{}.Path(), nil)
+	q := req.URL.Query()
+	req.URL.RawQuery = q.Encode()
+	resp, err := http.DefaultClient.Do(req)
+	a.Nil(err)
+	a.Equal(200, resp.StatusCode)
+}

--- a/internal/mock_api/endpoints/ccl/content_classification_labels.go
+++ b/internal/mock_api/endpoints/ccl/content_classification_labels.go
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package ccl
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/twitchdev/twitch-cli/internal/models"
+)
+
+var cclMethodsSupported = map[string]bool{
+	http.MethodGet:    true,
+	http.MethodPost:   false,
+	http.MethodDelete: false,
+	http.MethodPatch:  false,
+	http.MethodPut:    false,
+}
+
+var cclScopesByMethod = map[string][]string{
+	http.MethodGet:    {},
+	http.MethodPost:   {},
+	http.MethodDelete: {},
+	http.MethodPatch:  {},
+	http.MethodPut:    {},
+}
+
+type ContentClassificationLabels struct{}
+
+func (e ContentClassificationLabels) Path() string { return "/content_classification_labels" }
+
+func (e ContentClassificationLabels) GetRequiredScopes(method string) []string {
+	return cclScopesByMethod[method]
+}
+
+func (e ContentClassificationLabels) ValidMethod(method string) bool {
+	return cclMethodsSupported[method]
+}
+
+func (e ContentClassificationLabels) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		getContentClassificationLabels(w, r)
+		break
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+func getContentClassificationLabels(w http.ResponseWriter, r *http.Request) {
+	// TODO: locale param
+
+	allCCLs := []models.ContentClassificationLabel{}
+	for _, ccl := range models.CCL_MAP {
+		allCCLs = append(allCCLs, ccl)
+	}
+
+	bytes, _ := json.Marshal(
+		models.APIResponse{
+			Data: allCCLs,
+		},
+	)
+	w.Write(bytes)
+}

--- a/internal/mock_api/endpoints/channels/information.go
+++ b/internal/mock_api/endpoints/channels/information.go
@@ -54,6 +54,7 @@ type PatchInformationEndpointRequest struct {
 	BroadcasterLanguage string `json:"broadcaster_language"`
 	Title               string `json:"title"`
 	Delay               *int   `json:"delay"`
+	BrandedContent      *bool  `json:"is_branded_content"`
 	// TODO: tags
 	ContentClassificationLabels []PatchInformationEndpointRequestLabel `json:"content_classification_labels"`
 }
@@ -161,7 +162,10 @@ func patchInformation(w http.ResponseWriter, r *http.Request) {
 		delay = *params.Delay
 	}
 
-	// TODO: Branded content
+	isBrandedContent := u.IsBrandedContent
+	if params.BrandedContent != nil {
+		isBrandedContent = *params.BrandedContent
+	}
 
 	cclDbString, err := handleCCLs(u, params)
 	if err != nil {
@@ -171,12 +175,13 @@ func patchInformation(w http.ResponseWriter, r *http.Request) {
 
 	// Write
 	err = db.NewQuery(r, 100).UpdateChannel(broadcasterID, database.User{
-		ID:           broadcasterID,
-		Title:        params.Title,
-		Language:     params.BroadcasterLanguage,
-		CategoryID:   gameID,
-		Delay:        delay,
-		UnparsedCCLs: cclDbString,
+		ID:               broadcasterID,
+		Title:            params.Title,
+		Language:         params.BroadcasterLanguage,
+		CategoryID:       gameID,
+		Delay:            delay,
+		UnparsedCCLs:     cclDbString,
+		IsBrandedContent: isBrandedContent,
 	})
 	if err != nil {
 		if database.DatabaseErrorIs(err, sqlite3.ErrConstraintForeignKey) {

--- a/internal/mock_api/endpoints/endpoints.go
+++ b/internal/mock_api/endpoints/endpoints.go
@@ -6,6 +6,7 @@ import (
 	"github.com/twitchdev/twitch-cli/internal/mock_api"
 	"github.com/twitchdev/twitch-cli/internal/mock_api/endpoints/bits"
 	"github.com/twitchdev/twitch-cli/internal/mock_api/endpoints/categories"
+	"github.com/twitchdev/twitch-cli/internal/mock_api/endpoints/ccl"
 	"github.com/twitchdev/twitch-cli/internal/mock_api/endpoints/channel_points"
 	"github.com/twitchdev/twitch-cli/internal/mock_api/endpoints/channels"
 	"github.com/twitchdev/twitch-cli/internal/mock_api/endpoints/charity"
@@ -34,6 +35,7 @@ func All() []mock_api.MockEndpoint {
 		bits.Cheermotes{},
 		categories.Games{},
 		categories.TopGames{},
+		ccl.ContentClassificationLabels{},
 		channel_points.Redemption{},
 		channel_points.Reward{},
 		channels.CommercialEndpoint{},

--- a/internal/models/ccl.go
+++ b/internal/models/ccl.go
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package models
+
+type ContentClassificationLabel struct {
+	Description      string
+	ID               string
+	Name             string
+	RestrictedGaming bool // Restricts users from applying that CCL via the API. Currently only for MatureGame.
+}
+
+var CCL_MAP = map[string]ContentClassificationLabel{
+	"DrugsIntoxication": {
+		Description:      "Excessive tobacco glorification or promotion, any marijuana consumption/use, legal drug and alcohol induced intoxication, discussions of illegal drugs.",
+		ID:               "DrugsIntoxication",
+		Name:             "Drugs, Intoxication, or Excessive Tobacco Use",
+		RestrictedGaming: false,
+	},
+	"Gambling": {
+		Description:      "Participating in online or in-person gambling, poker or fantasy sports, that involve the exchange of real money.",
+		ID:               "Gambling",
+		Name:             "Gambling",
+		RestrictedGaming: false,
+	},
+	"MatureGame": {
+		Description:      "Games that are rated Mature or less suitable for a younger audience.",
+		ID:               "MatureGame",
+		Name:             "Mature-rated game",
+		RestrictedGaming: true,
+	},
+	"ProfanityVulgarity": {
+		Description:      "Prolonged, and repeated use of obscenities, profanities, and vulgarities, especially as a regular part of speech.",
+		ID:               "ProfanityVulgarity",
+		Name:             "Significant Profanity or Vulgarity",
+		RestrictedGaming: false,
+	},
+	"SexualThemes": {
+		Description:      "Content that focuses on sexualized physical attributes and activities, sexual topics, or experiences.",
+		ID:               "SexualThemes",
+		Name:             "Sexual Themes",
+		RestrictedGaming: false,
+	},
+	"ViolentGraphic": {
+		Description:      "Simulations and/or depictions of realistic violence, gore, extreme injury, or death.",
+		ID:               "ViolentGraphic",
+		Name:             "Violent and Graphic Depictions",
+		RestrictedGaming: false,
+	},
+}

--- a/internal/models/ccl.go
+++ b/internal/models/ccl.go
@@ -3,10 +3,10 @@
 package models
 
 type ContentClassificationLabel struct {
-	Description      string
-	ID               string
-	Name             string
-	RestrictedGaming bool // Restricts users from applying that CCL via the API. Currently only for MatureGame.
+	Description      string `json:"description"`
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	RestrictedGaming bool   `json:"-"` // Restricts users from applying that CCL via the API. Currently only for MatureGame.
 }
 
 var CCL_MAP = map[string]ContentClassificationLabel{

--- a/internal/models/channel_update.go
+++ b/internal/models/channel_update.go
@@ -10,7 +10,12 @@ type ChannelUpdateEventSubEvent struct {
 	StreamLanguage       string `json:"language"`
 	StreamCategoryID     string `json:"category_id"`
 	StreamCategoryName   string `json:"category_name"`
-	IsMature             bool   `json:"is_mature"`
+
+	// v1
+	IsMature *bool `json:"is_mature,omitempty"`
+
+	// v2
+	ContentClassificationLabels []string `json:"content_classification_labels,omitempty"`
 }
 
 type ChannelUpdateEventSubResponse struct {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Updated mock EventSub and mock API to include Content Classification Label updates.

## Description of Changes: 

- Added Mock API endpoint /content_classification_labels
- Updated /channels Mock API endpoint to include Content Classification Labels
- Added `is_branded_content` flag to /channels Mock API endpoint
- Split `channel.update` EventSub event into 1 and beta (which will be v2 in the future). beta/v2 supports CCL information

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
