### PR TITLE
Fixed deprecated gorelease flags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,16 +66,17 @@ builds:
       - windows
     goarch:
       - "386" 
-scoop:
-  bucket:
-    owner: twitchdev
-    name: scoop-bucket
-  homepage: https://github.com/twitchdev/twitch-cli
-  description: CLI for Twitch's developer offerings
-  license: Apache-2.0
+scoops:
+  -
+    repository:
+      owner: twitchdev
+      name: scoop-bucket
+    homepage: https://github.com/twitchdev/twitch-cli
+    description: CLI for Twitch's developer offerings
+    license: Apache-2.0
 brews:
   -
-    tap:
+    repository:
       owner: twitchdev
       name: homebrew-twitch
     folder: Formula
@@ -87,12 +88,7 @@ brews:
       system "#{bin}/twitch", "version"
     license: Apache-2.0
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{- title .Os }}_{{- if eq .Arch "386" }}i386{{- else if eq .Arch "amd64" }}x86_64{{- else }}{{ .Arch }}{{ end }}'
     format_overrides:
     - goos: windows
       format: zip

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ release:
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-w /go/src/github.com/twitchdev/twitch-cli \
 		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
-		twitch-cli:latest --rm-dist
+		twitch-cli:latest --clean
 
 test-release:
 	docker build . -t twitch-cli:latest
@@ -14,7 +14,7 @@ test-release:
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-w /go/src/github.com/twitchdev/twitch-cli \
 		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
-		twitch-cli:latest --rm-dist --skip-publish --snapshot
+		twitch-cli:latest --clean --skip-publish --snapshot
 	
 build:
 	go build --ldflags "-s -w -X main.buildVersion=source"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Some things for goreleaser were deprecated.

## Description of Changes: 

- --rm-dist is now --clean
- scoop is now scoops
- scoops.bucket is now scoops.repository
- brews.tap is now brews.repository
- archives.replacement is now archives.name_template

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
