### PR TITLE
Solving 264 and 265

### DIFF
--- a/internal/events/websocket/mock_server/client.go
+++ b/internal/events/websocket/mock_server/client.go
@@ -11,7 +11,7 @@ type Client struct {
 	clientName           string // Unique name for the client. Not the Client ID.
 	conn                 *websocket.Conn
 	mutex                sync.Mutex
-	ConnectedAtTimestamp string
+	ConnectedAtTimestamp string // RFC3339Nano timestamp indicating when the client connected to the server
 	connectionUrl        string
 
 	mustSubscribeTimer *time.Timer

--- a/internal/events/websocket/mock_server/manager.go
+++ b/internal/events/websocket/mock_server/manager.go
@@ -264,7 +264,7 @@ func subscriptionPageHandlerGet(w http.ResponseWriter, r *http.Request) {
 	for clientName, clientSubscriptions := range server.Subscriptions {
 		for _, subscription := range clientSubscriptions {
 			disabledAndExpired := false // Production EventSub only shows disabled WebSocket subscriptions that were disabled under 1 hour ago
-			if subscription.DisabledAt != nil && subscription.DisabledAt.Add(time.Minute*2).Before(util.GetTimestamp()) {
+			if subscription.DisabledAt != nil && subscription.DisabledAt.Add(time.Hour).Before(util.GetTimestamp()) {
 				disabledAndExpired = true
 			}
 

--- a/internal/events/websocket/mock_server/manager.go
+++ b/internal/events/websocket/mock_server/manager.go
@@ -270,7 +270,7 @@ func subscriptionPageHandlerGet(w http.ResponseWriter, r *http.Request) {
 
 			if clientID == "debug" || (subscription.ClientID == clientID && !disabledAndExpired) {
 				allSubscriptions = append(allSubscriptions, SubscriptionPostSuccessResponseBody{
-					ID:        subscription.ClientID,
+					ID:        subscription.SubscriptionID,
 					Status:    subscription.Status,
 					Type:      subscription.Type,
 					Version:   subscription.Version,

--- a/internal/events/websocket/mock_server/manager.go
+++ b/internal/events/websocket/mock_server/manager.go
@@ -263,7 +263,12 @@ func subscriptionPageHandlerGet(w http.ResponseWriter, r *http.Request) {
 
 	for clientName, clientSubscriptions := range server.Subscriptions {
 		for _, subscription := range clientSubscriptions {
-			if clientID == "debug" || subscription.ClientID == clientID {
+			disabledAndExpired := false // Production EventSub only shows disabled WebSocket subscriptions that were disabled under 1 hour ago
+			if subscription.DisabledAt != nil && subscription.DisabledAt.Add(time.Minute*2).Before(util.GetTimestamp()) {
+				disabledAndExpired = true
+			}
+
+			if clientID == "debug" || (subscription.ClientID == clientID && !disabledAndExpired) {
 				allSubscriptions = append(allSubscriptions, SubscriptionPostSuccessResponseBody{
 					ID:        subscription.ClientID,
 					Status:    subscription.Status,

--- a/internal/events/websocket/mock_server/rpc_handler.go
+++ b/internal/events/websocket/mock_server/rpc_handler.go
@@ -253,6 +253,12 @@ func RPCSubscriptionHandler(args rpc.RPCArgs) rpc.RPCResponse {
 				found = true
 
 				server.Subscriptions[client][i].Status = args.Variables["SubscriptionStatus"]
+				if args.Variables["SubscriptionStatus"] == STATUS_ENABLED {
+					server.Subscriptions[client][i].DisabledAt = nil
+				} else {
+					tNow := util.GetTimestamp()
+					server.Subscriptions[client][i].DisabledAt = &tNow
+				}
 				break
 			}
 		}

--- a/internal/events/websocket/mock_server/rpc_handler.go
+++ b/internal/events/websocket/mock_server/rpc_handler.go
@@ -117,10 +117,7 @@ func RPCFireEventSubHandler(args rpc.RPCArgs) rpc.RPCResponse {
 		}
 	}
 
-	clientName, exists := args.Variables["ClientName"]
-	if !exists {
-
-	}
+	clientName := args.Variables["ClientName"]
 	if sessionRegex.MatchString(clientName) {
 		// Users can include the full session_id given in the response. If they do, subtract it to just the client name
 		clientName = sessionRegex.FindAllStringSubmatch(clientName, -1)[0][2]

--- a/internal/events/websocket/mock_server/server.go
+++ b/internal/events/websocket/mock_server/server.go
@@ -410,6 +410,8 @@ func (ws *WebSocketServer) HandleRPCEventSubForwarding(eventsubBody string, clie
 						foundClientId = sub.ClientID
 
 						ws.Subscriptions[client][i].Status = STATUS_AUTHORIZATION_REVOKED
+						tNow := util.GetTimestamp()
+						ws.Subscriptions[client][i].DisabledAt = &tNow
 						break
 					}
 				}
@@ -503,9 +505,12 @@ func (ws *WebSocketServer) handleClientConnectionClose(client *Client, closeReas
 		subscriptions := ws.Subscriptions[client.clientName]
 		for i := range subscriptions {
 			if subscriptions[i].Status == STATUS_ENABLED {
+				tNow := util.GetTimestamp()
+
 				subscriptions[i].Status = getStatusFromCloseMessage(closeReason)
 				subscriptions[i].ClientConnectedAt = ""
-				subscriptions[i].ClientDisconnectedAt = time.Now().UTC().Format(time.RFC3339Nano)
+				subscriptions[i].ClientDisconnectedAt = tNow.Format(time.RFC3339Nano)
+				subscriptions[i].DisabledAt = &tNow
 			}
 		}
 		ws.Subscriptions[client.clientName] = subscriptions

--- a/internal/events/websocket/mock_server/subscription.go
+++ b/internal/events/websocket/mock_server/subscription.go
@@ -1,15 +1,20 @@
 package mock_server
 
-import "github.com/twitchdev/twitch-cli/internal/models"
+import (
+	"time"
+
+	"github.com/twitchdev/twitch-cli/internal/models"
+)
 
 type Subscription struct {
-	SubscriptionID    string // Random GUID for the subscription
-	ClientID          string // Client ID included in headers
-	Type              string // EventSub topic
-	Version           string // EventSub topic version
-	CreatedAt         string // Timestamp of when the subscription was created
-	Status            string // Status of the subscription
-	SessionClientName string // Client name of the session this is associated with.
+	SubscriptionID    string     // Random GUID for the subscription
+	ClientID          string     // Client ID included in headers
+	Type              string     // EventSub topic
+	Version           string     // EventSub topic version
+	CreatedAt         string     // Timestamp of when the subscription was created
+	DisabledAt        *time.Time // Not public; Timestamp of when the subscription was disabled
+	Status            string     // Status of the subscription
+	SessionClientName string     // Client name of the session this is associated with.
 
 	ClientConnectedAt    string // Time client connected
 	ClientDisconnectedAt string // Time client disconnected


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Two mock EventSub WebSocket server issues: #264 and #265

## Description of Changes: 

- Fixed #264 by setting created_at correctly during EventSub WebSocket servers
- Fixed #265 by adding time checks for mock `GET /eventsub/subscriptions`, now making expired subscriptions display only when they have expired within the last 60 minutes

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
