### PR TITLE
Added --validate flag to twitch token

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/twitchdev/twitch-cli/internal/login"
 
 	"github.com/spf13/cobra"
@@ -85,20 +86,23 @@ func loginCmdRun(cmd *cobra.Command, args []string) error {
 
 		expiresInTimestamp := time.Now().Add(time.Duration(r.ExpiresIn) * time.Second).UTC().Format(time.RFC1123)
 
-		println("Client ID: " + r.ClientID)
-		println("Token Type: " + tokenType)
+		lightYellow := color.New(color.FgHiYellow).PrintfFunc()
+		white := color.New(color.FgWhite).SprintfFunc()
+
+		lightYellow("Client ID: %v\n", white(r.ClientID))
+		lightYellow("Token Type: %v\n", white(tokenType))
 		if r.UserID != "" {
-			println("User ID: " + r.UserID)
-			println("User Login: " + r.UserLogin)
+			lightYellow("User ID: %v\n", white(r.UserID))
+			lightYellow("User Login: %v\n", white(r.UserLogin))
 		}
-		println("Expires In: " + strconv.FormatInt(r.ExpiresIn, 10) + " (" + expiresInTimestamp + ")")
+		lightYellow("Expires In: %v\n", white("%v (%v)", strconv.FormatInt(r.ExpiresIn, 10), expiresInTimestamp))
 
 		if len(r.Scopes) == 0 {
-			println("Scopes: None")
+			lightYellow("User ID: %v\n", white("None"))
 		} else {
-			println("Scopes:")
+			lightYellow("Scopes:\n")
 			for _, s := range r.Scopes {
-				println("- " + s)
+				fmt.Println(white("- %v\n", s))
 			}
 		}
 	} else if isUserToken == true {

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/twitchdev/twitch-cli/internal/login"
 
@@ -15,6 +16,7 @@ import (
 var isUserToken bool
 var userScopes string
 var revokeToken string
+var validateToken string
 var overrideClientId string
 var tokenServerPort int
 var tokenServerIP string
@@ -32,6 +34,7 @@ func init() {
 	loginCmd.Flags().BoolVarP(&isUserToken, "user-token", "u", false, "Whether to login as a user or getting an app access token.")
 	loginCmd.Flags().StringVarP(&userScopes, "scopes", "s", "", "Space separated list of scopes to request with your user token.")
 	loginCmd.Flags().StringVarP(&revokeToken, "revoke", "r", "", "Instead of generating a new token, revoke the one passed to this parameter.")
+	loginCmd.Flags().StringVarP(&validateToken, "validate", "v", "", "Instead of generating a new token, validate the one passed to this parameter.")
 	loginCmd.Flags().StringVar(&overrideClientId, "client-id", "", "Override/manually set client ID for token actions. By default client ID from CLI config will be used.")
 	loginCmd.Flags().StringVar(&tokenServerIP, "ip", "localhost", "Manually set the IP address to be binded to for the User Token web server.")
 	loginCmd.Flags().IntVarP(&tokenServerPort, "port", "p", 3000, "Manually set the port to be used for the User Token web server.")
@@ -67,6 +70,37 @@ func loginCmdRun(cmd *cobra.Command, args []string) error {
 		p.Token = revokeToken
 		p.URL = login.RevokeTokenURL
 		login.CredentialsLogout(p)
+	} else if validateToken != "" {
+		p.Token = validateToken
+		p.URL = login.ValidateTokenURL
+		r, err := login.ValidateCredentials(p)
+		if err != nil {
+			return fmt.Errorf("Failed to validate: %v", err.Error())
+		}
+
+		tokenType := "App Access Token"
+		if r.UserID != "" {
+			tokenType = "User Access Token"
+		}
+
+		expiresInTimestamp := time.Now().Add(time.Duration(r.ExpiresIn) * time.Second).UTC().Format(time.RFC1123)
+
+		println("Client ID: " + r.ClientID)
+		println("Token Type: " + tokenType)
+		if r.UserID != "" {
+			println("User ID: " + r.UserID)
+			println("User Login: " + r.UserLogin)
+		}
+		println("Expires In: " + strconv.FormatInt(r.ExpiresIn, 10) + " (" + expiresInTimestamp + ")")
+
+		if len(r.Scopes) == 0 {
+			println("Scopes: None")
+		} else {
+			println("Scopes:")
+			for _, s := range r.Scopes {
+				println("- " + s)
+			}
+		}
 	} else if isUserToken == true {
 		p.URL = login.UserCredentialsURL
 		login.UserCredentialsLogin(p, tokenServerIP, webserverPort)

--- a/internal/login/login_request.go
+++ b/internal/login/login_request.go
@@ -16,8 +16,21 @@ type loginRequestResponse struct {
 	Body       []byte
 }
 
+type loginHeader struct {
+	Key   string
+	Value string
+}
+
 func loginRequest(method string, url string, payload io.Reader) (loginRequestResponse, error) {
+	return loginRequestWithHeaders(method, url, payload, []loginHeader{})
+}
+
+func loginRequestWithHeaders(method string, url string, payload io.Reader, headers []loginHeader) (loginRequestResponse, error) {
 	req, err := request.NewRequest(method, url, payload)
+
+	for _, header := range headers {
+		req.Header.Add(header.Key, header.Value)
+	}
 
 	client := &http.Client{
 		Timeout: time.Second * 10,


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Solved #271 by adding --validate to twitch token

## Description of Changes: 

Added --validate flag to `twitch token`:
```
$ ./twitch-cli token --validate <user token>
Client ID: 718ozxefxg7qak0jsvmrahw9pq3qch
Token Type: User Access Token
User ID: 57047445
User Login: xemdo
Expires In: 15145 (Sat, 23 Sep 2023 06:15:33 UTC)
Scopes:
- channel:read:polls
- channel:read:vips
- user:read:follows
- user:read:subscriptions

$ ./twitch-cli token --validate <app token>
Client ID: dy5l2nnrf1fybxoupqb73kw5ksqhw6
Token Type: App Access Token
Expires In: 5053085 (Mon, 20 Nov 2023 13:41:43 UTC)
Scopes: None
```

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
