### PR TITLE
fix: use io and os instead of ioutil

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -4,8 +4,8 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/twitchdev/twitch-cli/internal/api"
@@ -136,7 +136,7 @@ func cmdRun(cmd *cobra.Command, args []string) error {
 }
 
 func getBodyFromFile(filename string) (string, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.7
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.8.4
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
 )
 
@@ -39,5 +39,5 @@ require (
 	golang.org/x/text v0.7.0 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -380,6 +382,8 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e h1:3i3ny04XV6HbZ2N1oIBw1UBYATHAOpo4tfTF83JM3Z0=
 gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/api/api_request.go
+++ b/internal/api/api_request.go
@@ -5,7 +5,7 @@ package api
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -49,7 +49,7 @@ func apiRequest(method string, url string, payload []byte, p apiRequestParameter
 		return apiRequestResponse{}, err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	defer resp.Body.Close()
 

--- a/internal/api/api_request_test.go
+++ b/internal/api/api_request_test.go
@@ -3,7 +3,7 @@
 package api
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -21,7 +21,7 @@ func TestApiRequest(t *testing.T) {
 		a.Equal("1234", r.Header.Get("Client-ID"), "Client ID invalid.")
 		a.Equal("Bearer 4567", r.Header.Get("Authorization"), "Token invalid.")
 
-		_, err := ioutil.ReadAll(r.Body)
+		_, err := io.ReadAll(r.Body)
 		a.Nil(err)
 	}))
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -3,7 +3,7 @@
 package api
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -21,7 +21,7 @@ func TestNewClient(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(ok))
 
-		_, err := ioutil.ReadAll(r.Body)
+		_, err := io.ReadAll(r.Body)
 		a.Nil(err)
 
 	}))
@@ -33,7 +33,7 @@ func TestNewClient(t *testing.T) {
 	resp, err := c.Do(req)
 	a.Nil(err)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	a.NoError(err)
 	a.Equal(ok, string(body), "Body mismatch")

--- a/internal/events/trigger/forward_event_test.go
+++ b/internal/events/trigger/forward_event_test.go
@@ -6,7 +6,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -29,7 +29,7 @@ func TestForwardEventEventsub(t *testing.T) {
 		a.NotEmpty(r.Header.Get("Twitch-Eventsub-Subscription-Type"))
 		a.NotEmpty(r.Header.Get("Twitch-Eventsub-Message-Id"))
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		a.Nil(err)
 		a.NotNil(body)
 

--- a/internal/events/trigger/retrigger_event_test.go
+++ b/internal/events/trigger/retrigger_event_test.go
@@ -4,7 +4,7 @@ package trigger
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -19,7 +19,7 @@ func TestRefireEvent(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 
-		_, err := ioutil.ReadAll(r.Body)
+		_, err := io.ReadAll(r.Body)
 		a.Nil(err)
 	}))
 	defer ts.Close()

--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/rpc"
 	"strings"
 	"time"
@@ -202,7 +202,7 @@ https://dev.twitch.tv/docs/eventsub/handling-webhook-events#processing-an-event`
 		}
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", err
 		}

--- a/internal/events/trigger/trigger_event_test.go
+++ b/internal/events/trigger/trigger_event_test.go
@@ -3,7 +3,7 @@
 package trigger
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -17,7 +17,7 @@ func TestFire(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 
-		_, err := ioutil.ReadAll(r.Body)
+		_, err := io.ReadAll(r.Body)
 		a.Nil(err)
 	}))
 	defer ts.Close()

--- a/internal/events/verify/subscription_verify.go
+++ b/internal/events/verify/subscription_verify.go
@@ -5,7 +5,7 @@ package verify
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net/http"
 	"net/url"
@@ -86,7 +86,7 @@ func VerifyWebhookSubscription(p VerifyParameters) (VerifyResponse, error) {
 		}
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return VerifyResponse{}, err
 		}

--- a/internal/events/verify/subscription_verify_test.go
+++ b/internal/events/verify/subscription_verify_test.go
@@ -4,7 +4,7 @@ package verify
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,7 +20,7 @@ func TestSubscriptionVerify(t *testing.T) {
 		var challenge string
 		w.WriteHeader(http.StatusAccepted)
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		a.Nil(err)
 
 		if r.Method == http.MethodPost {

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -233,7 +233,7 @@ func ValidateCredentials(p LoginParameters) (ValidateResponse, error) {
 	}
 
 	resp, err := loginRequestWithHeaders(http.MethodGet, u.String(), nil, []loginHeader{
-		loginHeader{
+		{
 			Key:   "Authorization",
 			Value: "OAuth " + p.Token,
 		},

--- a/internal/login/login_request.go
+++ b/internal/login/login_request.go
@@ -4,7 +4,6 @@ package login
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -40,7 +39,7 @@ func loginRequestWithHeaders(method string, url string, payload io.Reader, heade
 		return loginRequestResponse{}, err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	defer resp.Body.Close()
 

--- a/internal/login/login_request_test.go
+++ b/internal/login/login_request_test.go
@@ -3,7 +3,7 @@
 package login
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -19,7 +19,7 @@ func TestLoginRequest(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(ok))
 
-		_, err := ioutil.ReadAll(r.Body)
+		_, err := io.ReadAll(r.Body)
 		a.Nil(err)
 
 	}))


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

The ioutil has been deprecated as of 1.16 this fixes those warnings.

## Description of Changes: 

- Deprecated ioutil in favor of io and os

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
