### PR TITLE
Changed goreleaser to use correct GCC version for Linux arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,8 +34,8 @@ builds:
     binary: twitch
     env:
       - CGO_ENABLED=1
-      - CC=aarch64-linux-gnu-gcc-6
-      - CXX=aarch64-linux-gnu-g++-6
+      - CC=aarch64-linux-gnu-gcc-9
+      - CXX=aarch64-linux-gnu-g++-9
     goos:
       - linux
     goarch:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test-release:
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-w /go/src/github.com/twitchdev/twitch-cli \
 		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
-		twitch-cli:latest --clean --skip-publish --snapshot
+		twitch-cli:latest --clean --skip=publish --snapshot
 	
 build:
 	go build --ldflags "-s -w -X main.buildVersion=source"


### PR DESCRIPTION
`make release` and `make test-release` weren't working due to goreleaser issues with Linux on arm64. This fixes it