### PR TITLE
bind to 0.0.0.0 instead of localhost

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -21,6 +21,7 @@ var validateToken string
 var overrideClientId string
 var tokenServerPort int
 var tokenServerIP string
+var redirectHost string
 
 // loginCmd represents the login command
 var loginCmd = &cobra.Command{
@@ -37,8 +38,9 @@ func init() {
 	loginCmd.Flags().StringVarP(&revokeToken, "revoke", "r", "", "Instead of generating a new token, revoke the one passed to this parameter.")
 	loginCmd.Flags().StringVarP(&validateToken, "validate", "v", "", "Instead of generating a new token, validate the one passed to this parameter.")
 	loginCmd.Flags().StringVar(&overrideClientId, "client-id", "", "Override/manually set client ID for token actions. By default client ID from CLI config will be used.")
-	loginCmd.Flags().StringVar(&tokenServerIP, "ip", "localhost", "Manually set the IP address to be binded to for the User Token web server.")
+	loginCmd.Flags().StringVar(&tokenServerIP, "ip", "", "Manually set the IP address to be bound to for the User Token web server.")
 	loginCmd.Flags().IntVarP(&tokenServerPort, "port", "p", 3000, "Manually set the port to be used for the User Token web server.")
+	loginCmd.Flags().StringVar(&redirectHost, "redirect-host", "localhost", "Manually set the host to be used for the redirect URL")
 }
 
 func loginCmdRun(cmd *cobra.Command, args []string) error {
@@ -46,7 +48,7 @@ func loginCmdRun(cmd *cobra.Command, args []string) error {
 	clientSecret = viper.GetString("clientSecret")
 
 	webserverPort := strconv.Itoa(tokenServerPort)
-	redirectURL := fmt.Sprintf("http://%v:%v", tokenServerIP, webserverPort)
+	redirectURL := fmt.Sprintf("http://%v:%v", redirectHost, webserverPort)
 
 	if clientID == "" || clientSecret == "" {
 		println("No Client ID or Secret found in configuration. Triggering configuration now.")
@@ -76,7 +78,7 @@ func loginCmdRun(cmd *cobra.Command, args []string) error {
 		p.URL = login.ValidateTokenURL
 		r, err := login.ValidateCredentials(p)
 		if err != nil {
-			return fmt.Errorf("Failed to validate: %v", err.Error())
+			return fmt.Errorf("failed to validate: %v", err.Error())
 		}
 
 		tokenType := "App Access Token"
@@ -105,7 +107,7 @@ func loginCmdRun(cmd *cobra.Command, args []string) error {
 				fmt.Println(white("- %v\n", s))
 			}
 		}
-	} else if isUserToken == true {
+	} else if isUserToken {
 		p.URL = login.UserCredentialsURL
 		login.UserCredentialsLogin(p, tokenServerIP, webserverPort)
 	} else {

--- a/docs/token.md
+++ b/docs/token.md
@@ -97,12 +97,33 @@ Access tokens can be revoked with:
 twitch token -r 0123456789abcdefghijABCDEFGHIJ
 ```
 
+## Alternate IP for User Token Webserver
+
+If you'd like to bind the webserver used for user tokens (`-u` flag), you can override it with the `--ip` flag. For example:
+
+```
+twitch token -u --ip 127.0.0.1"
+```
+
 ## Alternate Port
 
 Port 3000 on localhost is used by default when fetching User Access Tokens. The `-p` flag can be used to change to another port if another service is already occupying that port. For example:
 
 ```
 twitch token -u -p 3030 -s "moderator:manage:shoutouts moderator:manage:shield_mode"
+```
+
+NOTE: You must update the first entry in the _OAuth Redirect URLs_ section of your app's management page in the [Developer's Application Console](https://dev.twitch.tv/console/apps) to match the new port number. Make sure there is no `/` at the end of the URL (e.g. use `http://localhost:3030` and not `http://localhost:3030/`) and that the URL is the first entry in the list if there is more than one.
+
+
+## Alternate Host
+
+If you'd like to change the hostname for one reason or another (e.g. binding to a local domain), you can use the `--redirect-host` to change the domain. You should _not_ prefix it with `http` or `https`.
+
+Example: 
+
+```
+twitch token -u --redirect-host contoso.com
 ```
 
 NOTE: You must update the first entry in the _OAuth Redirect URLs_ section of your app's management page in the [Developer's Application Console](https://dev.twitch.tv/console/apps) to match the new port number. Make sure there is no `/` at the end of the URL (e.g. use `http://localhost:3030` and not `http://localhost:3030/`) and that the URL is the first entry in the list if there is more than one.
@@ -126,14 +147,15 @@ None.
 
 **Flags**
 
-| Flag           | Shorthand | Description                                                                                           | Example                                      | Required? (Y/N) |
-|----------------|-----------|-------------------------------------------------------------------------------------------------------|----------------------------------------------|-----------------|
-| `--user-token` | `-u`      | Whether to fetch a user token or not. Default is false.                                               | `token -u`                                   | N               |
-| `--scopes`     | `-s`      | The space separated scopes to use when getting a user token.                                          | `-s "user:read:email user_read"`             | N               |
-| `--revoke`     | `-r`      | Instead of generating a new token, revoke the one passed to this parameter.                           | `-r 0123456789abcdefghijABCDEFGHIJ`          | N               |
-| `--port`       | `-p`      | Override/manually set the port for token actions. (The default is 3000)                               | `-p 3030`                                    | N               |
-| `--client-id`  |           | Override/manually set client ID for token actions. By default client ID from CLI config will be used. | `--client-id uo6dggojyb8d6soh92zknwmi5ej1q2` | N               |
-
+| Flag              | Shorthand | Description                                                                                                    | Example                                      | Required? (Y/N) |
+|-------------------|-----------|----------------------------------------------------------------------------------------------------------------|----------------------------------------------|-----------------|
+| `--user-token`    | `-u`      | Whether to fetch a user token or not. Default is false.                                                        | `token -u`                                   | N               |
+| `--scopes`        | `-s`      | The space separated scopes to use when getting a user token.                                                   | `-s "user:read:email user_read"`             | N               |
+| `--revoke`        | `-r`      | Instead of generating a new token, revoke the one passed to this parameter.                                    | `-r 0123456789abcdefghijABCDEFGHIJ`          | N               |
+| `--ip`            |           | Manually set the port to be used for the User Token web server. The default binds to all interfaces. (0.0.0.0) | `--ip 127.0.0.1`                             | N               |
+| `--port`          | `-p`      | Override/manually set the port for token actions. (The default is 3000)                                        | `-p 3030`                                    | N               |
+| `--client-id`     |           | Override/manually set client ID for token actions. By default client ID from CLI config will be used.          | `--client-id uo6dggojyb8d6soh92zknwmi5ej1q2` | N               |
+| `--redirect-host` |           | Override/manually set the redirect host token actions. The default is `localhost`                              | `--redirect-host contoso.com`                | N               |
 
 ## Notes
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

The `twitch token -u` command was broken on WSL2 machines as it bound to `localhost` by default. Unfortunately this lead to the case where the webserver was local to the WSL2 image only, thus being inaccessible to the Windows host itself. 

This now binds the webserver to `0.0.0.0` by default, and then allows this to be overridden by passing the `--ip` flag whilst not affecting the rediect URL as it was before using a new `--redirect-host`. 

## Description of Changes: 

- Adds new `--redirect-host` flag that allows for changing the redirect URL without affecting the webserver binding
- Documented the changes

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
