### PR TITLE
adds missing version parameter to verify-subscription

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -319,6 +319,7 @@ https://dev.twitch.tv/docs/eventsub/handling-webhook-events#processing-an-event`
 		Secret:         secret,
 		Timestamp:      timestamp,
 		EventID:        eventID,
+		Version:        version,
 	})
 
 	if err != nil {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

#288 flagged that `--version` didn't work for `twitch event verify-subscription`. This was due to a missing entry into the parameters- it should correctly pass through as needed to avoid this in the future.

## Description of Changes: 

- Adds `version` to the verify-subscription parameters as needed.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [ ] I have updated the documentation (if applicable)
