### PR TITLE
allows users to pass broadcaster IDs into verify-subscription

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -176,6 +176,7 @@ func init() {
 	verifyCmd.Flags().StringVar(&timestamp, "timestamp", "", "Sets the timestamp to be used in payloads and headers. Must be in RFC3339Nano format.")
 	verifyCmd.Flags().StringVarP(&eventID, "subscription-id", "u", "", "Manually set the subscription/event ID of the event itself.") // TODO: This description will need to change with https://github.com/twitchdev/twitch-cli/issues/184
 	verifyCmd.Flags().StringVarP(&version, "version", "v", "", "Chooses the EventSub version used for a specific event. Not required for most events.")
+	verifyCmd.Flags().StringVarP(&toUser, "broadcaster", "b", "", "User ID of the broadcaster for the verification event.")
 	verifyCmd.MarkFlagRequired("forward-address")
 
 	// websocket flags
@@ -313,12 +314,13 @@ https://dev.twitch.tv/docs/eventsub/handling-webhook-events#processing-an-event`
 	}
 
 	_, err := verify.VerifyWebhookSubscription(verify.VerifyParameters{
-		Event:          args[0],
-		Transport:      transport,
-		ForwardAddress: forwardAddress,
-		Secret:         secret,
-		Timestamp:      timestamp,
-		EventID:        eventID,
+		Event:             args[0],
+		Transport:         transport,
+		ForwardAddress:    forwardAddress,
+		Secret:            secret,
+		Timestamp:         timestamp,
+		EventID:           eventID,
+		BroadcasterUserID: toUser,
 	})
 
 	if err != nil {

--- a/docs/event.md
+++ b/docs/event.md
@@ -5,7 +5,7 @@
   - [Trigger](#trigger)
   - [Retrigger](#retrigger)
   - [Verify-Subscription](#verify-subscription)
-  - [Websocket](#websocket)
+  - [WebSocket](#websocket)
 
 ## Description
 
@@ -154,6 +154,7 @@ This command takes the same arguments as [Trigger](#trigger).
 
 | Flag                | Shorthand | Description                                                                                                          | Example                     | Required? (Y/N) |
 |---------------------|-----------|----------------------------------------------------------------------------------------------------------------------|-----------------------------|-----------------|
+| `--broadcaster`     | `-b`      | The broadcaster's user ID to be used for verification                                                              | `-b 1234`                   | N               |
 | `--forward-address` | `-F`      | Web server address for where to send mock subscription.                                                              | `-F https://localhost:8080` | Y               |
 | `--secret`          | `-s`      | Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC and must be 10-100 characters in length. | `-s testsecret`             | N               |
 | `--transport`       | `-T`      | The method used to send events. Default is `eventsub`.                                                               | `-T eventsub`               | N               |


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

#103 identified a gap in the ability to pass the broadcaster's user ID into the subscription payload, which this now enables.

## Description of Changes: 

- Adds `--broadcaster` and `-b` to the `verify-subscription` subcommand which is passed to the subscription body.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
