### PR TITLE
Support for larger drop payloads

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -149,7 +149,7 @@ func init() {
 	triggerCmd.Flags().StringVarP(&subscriptionStatus, "subscription-status", "r", "enabled", "Status of the Subscription object (.subscription.status in JSON). Defaults to \"enabled\".")
 	triggerCmd.Flags().StringVarP(&itemID, "item-id", "i", "", "Manually set the ID of the event payload item (for example the reward ID in redemption events). For stream events, this is the game ID.")
 	triggerCmd.Flags().StringVarP(&itemName, "item-name", "n", "", "Manually set the name of the event payload item (for example the reward ID in redemption events). For stream events, this is the game title.")
-	triggerCmd.Flags().Int64VarP(&cost, "cost", "C", 0, "Amount of subscriptions, bits, or channel points redeemed/used in the event.")
+	triggerCmd.Flags().Int64VarP(&cost, "cost", "C", 0, "Amount of drops, subscriptions, bits, or channel points redeemed/used in the event.")
 	triggerCmd.Flags().StringVarP(&description, "description", "d", "", "Title the stream should be updated with.")
 	triggerCmd.Flags().StringVarP(&gameID, "game-id", "G", "", "Sets the game/category ID for applicable events.")
 	triggerCmd.Flags().StringVarP(&tier, "tier", "", "", "Sets the subscription tier. Valid values are 1000, 2000, and 3000.")

--- a/internal/events/types/drop/drop.go
+++ b/internal/events/types/drop/drop.go
@@ -41,6 +41,41 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook:
 		campaignId := util.RandomGUID()
 
+		dropEvents := []models.DropsEntitlementEventSubEvent{
+			{
+				ID: util.RandomGUID(),
+				Data: models.DropsEntitlementEventSubEventData{
+					OrganizationID: params.FromUserID,
+					CategoryID:     params.GameID,
+					CategoryName:   "Special Events",
+					CampaignID:     campaignId,
+					EntitlementID:  util.RandomGUID(),
+					BenefitID:      params.ItemID,
+					UserID:         params.ToUserID,
+					UserName:       params.ToUserName,
+					UserLogin:      params.ToUserName,
+					CreatedAt:      params.Timestamp,
+				},
+			},
+		}
+
+		for i := int64(1); i < params.Cost; i++ {
+			// for the new events, we'll use the entitlement above except generating new users as to avoid conflicting drops
+			dropEvents = append(dropEvents, models.DropsEntitlementEventSubEvent{
+				ID: util.RandomGUID(),
+				Data: models.DropsEntitlementEventSubEventData{
+					OrganizationID: params.FromUserID,
+					CategoryID:     params.GameID,
+					CategoryName:   "Special Events",
+					CampaignID:     campaignId,
+					EntitlementID:  util.RandomGUID(),
+					BenefitID:      params.ItemID,
+					UserID:         util.RandomUserID(),
+					UserName:       params.ToUserName,
+					UserLogin:      params.ToUserName,
+					CreatedAt:      params.Timestamp,
+				}})
+		}
 		body := &models.DropsEntitlementEventSubResponse{
 			Subscription: models.EventsubSubscription{
 				ID:      params.ID,
@@ -59,23 +94,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				Cost:      0,
 				CreatedAt: params.Timestamp,
 			},
-			Events: []models.DropsEntitlementEventSubEvent{
-				{
-					ID: util.RandomGUID(),
-					Data: models.DropsEntitlementEventSubEventData{
-						OrganizationID: params.FromUserID,
-						CategoryID:     params.GameID,
-						CategoryName:   "Special Events",
-						CampaignID:     campaignId,
-						EntitlementID:  util.RandomGUID(),
-						BenefitID:      params.ItemID,
-						UserID:         params.ToUserID,
-						UserName:       params.ToUserName,
-						UserLogin:      params.ToUserName,
-						CreatedAt:      params.Timestamp,
-					},
-				},
-			},
+			Events: dropEvents,
 		}
 		event, err = json.Marshal(body)
 		if err != nil {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Allows for the `twitch event trigger drop.entitlement.grant` to leverage the `--cost`/`-C` flag to pass a number of drops for the payload. 

The payload will generate fresh IDs per event as to avoid causing collisions for developers, but otherwise works as advertised. 

## Description of Changes: 

- Allows for developers to state the number of Drops per event via the above flags.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [ ] I have updated the documentation (if applicable)
