### PR TITLE
Fix scope name for mock-api POST /chat/shoutouts endpoint

### DIFF
--- a/internal/mock_api/endpoints/chat/shoutouts.go
+++ b/internal/mock_api/endpoints/chat/shoutouts.go
@@ -20,7 +20,7 @@ var shoutoutsMethodsSupported = map[string]bool{
 
 var shoutoutsScopesByMethod = map[string][]string{
 	http.MethodGet:    {},
-	http.MethodPost:   {"moderator:manage:shoutout"},
+	http.MethodPost:   {"moderator:manage:shoutouts"},
 	http.MethodDelete: {},
 	http.MethodPatch:  {},
 	http.MethodPut:    {},


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

According to the official Docs, the mock-api got a misspelled scope in POST /chat/shoutouts endpoint.

## Description of Changes: 

- Changed scopes name from [`moderator:manage:shoutout` to `moderator:manage:shoutouts`](https://dev.twitch.tv/docs/authentication/scopes/#twitch-api-scopes)

Sidenote: For some reason, GitHub shows that I've completely replaced this file, but I only changed the scope. I'd guess the line endings have changed. Is there a guideline for these kind of things?

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
