### PR TITLE
Added RPC command to disable keepalive messages for a client; #291

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -53,15 +53,16 @@ var (
 
 // websocketCmd-specific flags
 var (
-	wsDebug        bool
-	wsStrict       bool
-	wsClient       string
-	wsSubscription string
-	wsStatus       string
-	wsReason       string
-	wsServerIP     string
-	wsServerPort   int
-	wsSSL          bool
+	wsDebug          bool
+	wsStrict         bool
+	wsClient         string
+	wsSubscription   string
+	wsStatus         string
+	wsReason         string
+	wsServerIP       string
+	wsServerPort     int
+	wsSSL            bool
+	wsFeatureEnabled bool
 )
 
 var eventCmd = &cobra.Command{
@@ -108,7 +109,8 @@ var websocketCmd = &cobra.Command{
 	Example: fmt.Sprintf(`  twitch event websocket start-server
   twitch event websocket reconnect
   twitch event websocket close --session=e411cc1e_a2613d4e --reason=4006
-  twitch event websocket subscription --status=user_removed --subscription=82a855-fae8-93bff0`,
+  twitch event websocket subscription --status=user_removed --subscription=82a855-fae8-93bff0
+  twitch event websocket keepalive --session=e411cc1e_a2613d4e --enabled=false`,
 	),
 	Aliases: []string{
 		"websockets",
@@ -205,6 +207,7 @@ func init() {
 	websocketCmd.Flags().StringVar(&wsSubscription, "subscription", "", `Subscription to target with your server command. Used with "websocket subscription".`)
 	websocketCmd.Flags().StringVar(&wsStatus, "status", "", `Changes the status of an existing subscription. Used with "websocket subscription".`)
 	websocketCmd.Flags().StringVar(&wsReason, "reason", "", `Sets the close reason when sending a Close message to the client. Used with "websocket close".`)
+	websocketCmd.Flags().BoolVar(&wsFeatureEnabled, "enabled", false, "Sets on/off for the specified feature.")
 
 	// configure flags
 	configureEventCmd.Flags().StringVarP(&forwardAddress, "forward-address", "F", "", "Forward address for mock event (webhook only).")
@@ -366,7 +369,7 @@ https://dev.twitch.tv/docs/eventsub/handling-webhook-events#processing-an-event`
 		Timestamp:         timestamp,
 		EventID:           eventID,
 		BroadcasterUserID: toUser,
-		Version:        version,
+		Version:           version,
 	})
 
 	if err != nil {
@@ -393,6 +396,7 @@ func websocketCmdRun(cmd *cobra.Command, args []string) error {
 			Subscription:       wsSubscription,
 			SubscriptionStatus: wsStatus,
 			CloseReason:        wsReason,
+			FeatureEnabled:     wsFeatureEnabled,
 		})
 
 		return err

--- a/docs/event.md
+++ b/docs/event.md
@@ -171,7 +171,7 @@ This command takes the same arguments as [Trigger](#trigger).
 
 | Flag                | Shorthand | Description                                                                                                          | Example                     | Required? (Y/N) |
 |---------------------|-----------|----------------------------------------------------------------------------------------------------------------------|-----------------------------|-----------------|
-| `--broadcaster`     | `-b`      | The broadcaster's user ID to be used for verification                                                              | `-b 1234`                   | N               |
+| `--broadcaster`     | `-b`      | The broadcaster's user ID to be used for verification                                                                | `-b 1234`                   | N               |
 | `--forward-address` | `-F`      | Web server address for where to send mock subscription.                                                              | `-F https://localhost:8080` | Y               |
 | `--no-config`       | `-D`      | Disables the use of the configuration values should they exist.                                                      | `-D`                        | N               |
 | `--secret`          | `-s`      | Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC and must be 10-100 characters in length. | `-s testsecret`             | N               |
@@ -210,6 +210,7 @@ Provides access to a mock EventSub WebSocket server. More information can be fou
 | `--reason`       |           | Specifies the Close message code you wish to close a client’s connection with. Only used with "twitch websocket close"       | `twitch event websocket close --reason=4006` |
 | `--status`       |           | Specifies the Status code you wish to override an existing subscription’s status to. Only used with "twitch websocket close" | `twitch event websocket subscription --status=user_removed` |
 | `--subscription` |           | Specifies the subscription ID you wish to target. Only used with “twitch websocket subscription”.	                          | `twitch event websocket subscription --subscription=48d3-b9a-f84c` |
+| `--enabled`      |           | Sets on/off for the specified feature.                                                           	                          | `twitch event websocket keepalive --session=e411cc1e_a2613d4e --enabled=false` |
 
 **Examples**
 
@@ -218,4 +219,5 @@ twitch event websocket start-server
 twitch event websocket reconnect
 twitch event websocket close --session=e411cc1e_a2613d4e --reason=4006
 twitch event websocket subscription --status=user_removed --subscription=82a855-fae8-93bff0
+twitch event websocket keepalive --session=e411cc1e_a2613d4e --enabled=false
 ```

--- a/internal/events/websocket/mock_server/client.go
+++ b/internal/events/websocket/mock_server/client.go
@@ -13,6 +13,7 @@ type Client struct {
 	mutex                sync.Mutex
 	ConnectedAtTimestamp string // RFC3339Nano timestamp indicating when the client connected to the server
 	connectionUrl        string
+	KeepAliveEnabled     bool
 
 	mustSubscribeTimer *time.Timer
 	keepAliveChanOpen  bool

--- a/internal/events/websocket/mock_server/manager.go
+++ b/internal/events/websocket/mock_server/manager.go
@@ -154,6 +154,7 @@ func StartWebsocketServer(enableDebug bool, ip string, port int, enableSSL bool,
 	rpc.RegisterHandler("EventSubWebSocketForwardEvent", RPCFireEventSubHandler)
 	rpc.RegisterHandler("EventSubWebSocketCloseClient", RPCCloseHandler)
 	rpc.RegisterHandler("EventSubWebSocketSubscription", RPCSubscriptionHandler)
+	rpc.RegisterHandler("EventSubWebSocketKeepalive", RPCKeepaliveHandler)
 	rpc.StartBackgroundServer()
 
 	// TODO: Interactive shell maybe?

--- a/internal/events/websocket/websocket_cmd.go
+++ b/internal/events/websocket/websocket_cmd.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"fmt"
 	"net/rpc"
+	"strconv"
 
 	"github.com/fatih/color"
 	"github.com/twitchdev/twitch-cli/internal/events/websocket/mock_server"
@@ -14,6 +15,7 @@ type WebsocketCommandParameters struct {
 	Subscription       string
 	SubscriptionStatus string
 	CloseReason        string
+	FeatureEnabled     bool
 }
 
 func ForwardWebsocketCommand(cmd string, p WebsocketCommandParameters) error {
@@ -36,6 +38,7 @@ func ForwardWebsocketCommand(cmd string, p WebsocketCommandParameters) error {
 	variables["SubscriptionID"] = p.Subscription
 	variables["SubscriptionStatus"] = p.SubscriptionStatus
 	variables["CloseReason"] = p.CloseReason
+	variables["FeatureEnabled"] = strconv.FormatBool(p.FeatureEnabled)
 
 	args := &rpc_handler.RPCArgs{
 		RPCName:   rpcName,


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Resolves #291 by adding the requested feature

## Description of Changes: 

- Added command `twitch event websocket keepalive --session=<Session ID> --enabled=<true/false>`
- Added `--enabled` flag for this command and future feature toggling

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
