### PR TITLE
Added description for the `-v` `--validate` flag in Command Line Notes table in token.md

### DIFF
--- a/docs/token.md
+++ b/docs/token.md
@@ -152,6 +152,7 @@ None.
 | `--user-token`    | `-u`      | Whether to fetch a user token or not. Default is false.                                                        | `token -u`                                   | N               |
 | `--scopes`        | `-s`      | The space separated scopes to use when getting a user token.                                                   | `-s "user:read:email user_read"`             | N               |
 | `--revoke`        | `-r`      | Instead of generating a new token, revoke the one passed to this parameter.                                    | `-r 0123456789abcdefghijABCDEFGHIJ`          | N               |
+| `--validate`      | `-v`      | Instead of generating a new token, validate the one passed to this parameter.                                  | `-v 0123456789abcdefghijABCDEFGHIJ`          | N               |
 | `--ip`            |           | Manually set the port to be used for the User Token web server. The default binds to all interfaces. (0.0.0.0) | `--ip 127.0.0.1`                             | N               |
 | `--port`          | `-p`      | Override/manually set the port for token actions. (The default is 3000)                                        | `-p 3030`                                    | N               |
 | `--client-id`     |           | Override/manually set client ID for token actions. By default client ID from CLI config will be used.          | `--client-id uo6dggojyb8d6soh92zknwmi5ej1q2` | N               |


### PR DESCRIPTION
Added --validate / -v flag to command line notes table

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Command Line Notes table in `token.md` file in documentation was missing description for `v` `validate` flag

## Description of Changes: 

- I added this description. Values for Description and Example table fields were taken from the source code of `cmd/token.go` file

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
