### PR TITLE
Refreshing access tokens on demand

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -152,7 +152,12 @@ func loginCmdRun(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("%v\n%v", err.Error(), errDescription)
 		}
 
-		fmt.Printf("%v", resp)
+		lightYellow := color.New(color.FgHiYellow).SprintfFunc()
+
+		log.Println("Successfully refreshed Access Token.")
+		log.Println(lightYellow("Access Token: ") + resp.Response.AccessToken)
+		log.Println(lightYellow("Refresh Token: ") + resp.Response.RefreshToken)
+		log.Println(lightYellow("Expires At: ") + resp.ExpiresAt.String())
 
 	} else if isUserToken {
 		p.URL = login.UserCredentialsURL
@@ -182,6 +187,8 @@ func loginCmdRun(cmd *cobra.Command, args []string) error {
 
 		log.Println("Successfully generated App Access Token.")
 		log.Println(lightYellow("App Access Token: ") + resp.Response.AccessToken)
+		log.Println(lightYellow("Expires At: ") + resp.ExpiresAt.String())
+		log.Println(lightYellow("Scopes: ") + fmt.Sprintf("%v", resp.Response.Scope))
 	}
 
 	return nil

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -313,9 +314,9 @@ func GetClientInformation() (clientInformation, error) {
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
 			URL:          login.RefreshTokenURL,
-		})
+		}, true)
 		if err != nil {
-			return clientInformation{}, err
+			return clientInformation{}, errors.New(err.Error() + "\nPlease rerun `twitch configure`")
 		}
 		token = r.Response.AccessToken
 	}

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -126,7 +126,7 @@ func TestRefreshUserToken(t *testing.T) {
 		URL:          ts.URL + "?foo=bar",
 		ClientID:     params.ClientID,
 		ClientSecret: params.ClientSecret,
-	})
+	}, true)
 
 	a.Nil(err)
 	a.NotNil(resp)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Adding a feature to refresh access tokens via the CLI.
Resolves #307

## Description of Changes: 

- Added `--refresh` flag to `twitch token`, allowing users to refresh their access tokens.
- Added `--secret` flag to `twitch token`, allowing users to override the Client Secret as it currently defaults to the one in the config.
- Moved error handling and messaging for token and login stuffs upstream out of login.go and into callers like token.go

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
