### PR TITLE
ws mock server keepalive_timeout_seconds query parameter support

### DIFF
--- a/internal/events/websocket/mock_server/client.go
+++ b/internal/events/websocket/mock_server/client.go
@@ -19,6 +19,7 @@ type Client struct {
 	keepAliveChanOpen  bool
 	keepAliveLoopChan  chan struct{}
 	keepAliveTimer     *time.Ticker
+	keepAliveSeconds   int
 	pingChanOpen       bool
 	pingLoopChan       chan struct{}
 	pingTimer          *time.Ticker


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Adds support for the keepalive_timeout_seconds query parameter to the EventSub WebSocket mock server

## Description of Changes: 

- Adds support for the keepalive_timeout_seconds query parameter for the EventSub WebSocket mock server

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
