### PR TITLE
Forwarding events carried over WebSockets reconnect doesn't work

### DIFF
--- a/internal/events/websocket/mock_server/manager.go
+++ b/internal/events/websocket/mock_server/manager.go
@@ -392,7 +392,6 @@ func subscriptionPageHandlerPost(w http.ResponseWriter, r *http.Request) {
 		Version:           body.Version,
 		CreatedAt:         time.Now().UTC().Format(time.RFC3339Nano),
 		Status:            STATUS_ENABLED, // https://dev.twitch.tv/docs/api/reference/#get-eventsub-subscriptions
-		SessionClientName: clientName,
 		Conditions:        body.Condition,
 		ClientConnectedAt: client.ConnectedAtTimestamp,
 	}

--- a/internal/events/websocket/mock_server/manager.go
+++ b/internal/events/websocket/mock_server/manager.go
@@ -170,23 +170,23 @@ func printWelcomeMsg() {
 
 	log.Printf(lightBlue("Started WebSocket server on %v:%v"), serverManager.ip, serverManager.port)
 	if serverManager.strictMode {
-		log.Printf(lightBlue("--require-subscription enabled. Clients will have 10 seconds to subscribe before being disconnected."))
+		log.Println(lightBlue("--require-subscription enabled. Clients will have 10 seconds to subscribe before being disconnected."))
 	}
 
 	fmt.Println()
 
 	log.Printf(yellow("Simulate subscribing to events at: %v://%v:%v/eventsub/subscriptions"), serverManager.protocolHttp, serverManager.ip, serverManager.port)
-	log.Printf(yellow("POST, GET, and DELETE are supported"))
-	log.Printf(yellow("For more info: https://dev.twitch.tv/docs/cli/websocket-event-command/#simulate-subscribing-to-mock-eventsub"))
+	log.Println(yellow("POST, GET, and DELETE are supported"))
+	log.Println(yellow("For more info: https://dev.twitch.tv/docs/cli/websocket-event-command/#simulate-subscribing-to-mock-eventsub"))
 
 	fmt.Println()
 
-	log.Printf(lightYellow("Events can be forwarded to this server from another terminal with --transport=websocket\nExample: \"twitch event trigger channel.ban --transport=websocket\""))
+	log.Println(lightYellow("Events can be forwarded to this server from another terminal with --transport=websocket\nExample: \"twitch event trigger channel.ban --transport=websocket\""))
 	fmt.Println()
-	log.Printf(lightYellow("You can send to a specific client after its connected with --session\nExample: \"twitch event trigger channel.ban --transport=websocket --session=e411cc1e_a2613d4e\""))
+	log.Println(lightYellow("You can send to a specific client after its connected with --session\nExample: \"twitch event trigger channel.ban --transport=websocket --session=e411cc1e_a2613d4e\""))
 
 	fmt.Println()
-	log.Printf(lightGreen("For further usage information, please see our official documentation:\nhttps://dev.twitch.tv/docs/cli/websocket-event-command/"))
+	log.Println(lightGreen("For further usage information, please see our official documentation:\nhttps://dev.twitch.tv/docs/cli/websocket-event-command/"))
 	fmt.Println()
 
 	log.Printf(lightBlue("Connect to the WebSocket server at: ")+"%v://%v:%v/ws", serverManager.protocolWs, serverManager.ip, serverManager.port)
@@ -443,8 +443,6 @@ func subscriptionPageHandlerPost(w http.ResponseWriter, r *http.Request) {
 			subscription.SubscriptionID,
 		)
 	}
-
-	return
 }
 
 func subscriptionPageHandlerDelete(w http.ResponseWriter, r *http.Request) {

--- a/internal/events/websocket/mock_server/server.go
+++ b/internal/events/websocket/mock_server/server.go
@@ -457,13 +457,13 @@ func (ws *WebSocketServer) HandleRPCEventSubForwarding(eventsubBody string, clie
 		subscriptionCreatedAtTimestamp := "" // Used below if in strict mode
 		if ws.StrictMode {
 			found := false
-			for _, clientSubscriptions := range ws.Subscriptions {
+			for subscriptionClientName, clientSubscriptions := range ws.Subscriptions {
 				if found {
 					break
 				}
 
 				for _, sub := range clientSubscriptions {
-					if sub.SessionClientName == client.clientName && sub.Type == eventObj.Subscription.Type && sub.Version == eventObj.Subscription.Version {
+					if subscriptionClientName == client.clientName && sub.Type == eventObj.Subscription.Type && sub.Version == eventObj.Subscription.Version {
 						found = true
 						subscriptionCreatedAtTimestamp = sub.CreatedAt
 					}
@@ -514,7 +514,7 @@ func (ws *WebSocketServer) HandleRPCEventSubForwarding(eventsubBody string, clie
 	}
 
 	if !didSend {
-		msg := fmt.Sprintf("Error executing remote triggered EventSub: No clients with the subscribed to [%v / %v]", eventObj.Subscription.Type, eventObj.Subscription.Version)
+		msg := fmt.Sprintf("Error executing remote triggered EventSub: No clients are subscribed to [%v / %v]", eventObj.Subscription.Type, eventObj.Subscription.Version)
 		log.Println(msg)
 		return false, msg
 	}

--- a/internal/events/websocket/mock_server/server.go
+++ b/internal/events/websocket/mock_server/server.go
@@ -154,14 +154,12 @@ func (ws *WebSocketServer) WsPageHandler(w http.ResponseWriter, r *http.Request)
 	client.mustSubscribeTimer = time.NewTimer(10 * time.Second)
 	if ws.StrictMode {
 		go func() {
-			select {
-			case <-client.mustSubscribeTimer.C:
-				if len(ws.Subscriptions[client.clientName]) == 0 {
-					client.CloseWithReason(closeConnectionUnused)
-					ws.handleClientConnectionClose(client, closeConnectionUnused)
+			<-client.mustSubscribeTimer.C
+			if len(ws.Subscriptions[client.clientName]) == 0 {
+				client.CloseWithReason(closeConnectionUnused)
+				ws.handleClientConnectionClose(client, closeConnectionUnused)
 
-					return
-				}
+				return
 			}
 		}()
 	}
@@ -270,8 +268,6 @@ func (ws *WebSocketServer) WsPageHandler(w http.ResponseWriter, r *http.Request)
 			ws.handleClientConnectionClose(client, closeClientSentInboundTraffic)
 			ws.muClients.Unlock()
 		}
-
-		break
 	}
 }
 

--- a/internal/events/websocket/mock_server/subscription.go
+++ b/internal/events/websocket/mock_server/subscription.go
@@ -7,14 +7,13 @@ import (
 )
 
 type Subscription struct {
-	SubscriptionID    string     // Random GUID for the subscription
-	ClientID          string     // Client ID included in headers
-	Type              string     // EventSub topic
-	Version           string     // EventSub topic version
-	CreatedAt         string     // Timestamp of when the subscription was created
-	DisabledAt        *time.Time // Not public; Timestamp of when the subscription was disabled
-	Status            string     // Status of the subscription
-	SessionClientName string     // Client name of the session this is associated with.
+	SubscriptionID string     // Random GUID for the subscription
+	ClientID       string     // Client ID included in headers
+	Type           string     // EventSub topic
+	Version        string     // EventSub topic version
+	CreatedAt      string     // Timestamp of when the subscription was created
+	DisabledAt     *time.Time // Not public; Timestamp of when the subscription was disabled
+	Status         string     // Status of the subscription
 
 	ClientConnectedAt    string // Time client connected
 	ClientDisconnectedAt string // Time client disconnected


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

See #315.

**NOTE:** Overall this is a bigger tech debt issue that I described in #317. This fix resolves the issue for end-users, but does not fix the underlying mistakes that led to this issue.

## Description of Changes: 

- Fixed issue by removing the subscription object's awareness of the client name. It already lived in the map that held the Subscription objects, so we will rely on this from now on to avoid duplicating info.

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
