### PR TITLE
Updated error message when forwarding WebSocket events

### DIFF
--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -221,7 +221,10 @@ https://dev.twitch.tv/docs/eventsub/handling-webhook-events#processing-an-event`
 	if strings.EqualFold(p.Transport, "websocket") {
 		client, err := rpc.DialHTTP("tcp", ":44747")
 		if err != nil {
-			return "", errors.New("Failed to dial RPC handler for WebSocket server. Is it online?\nError: " + err.Error())
+			return "", errors.New(
+				"Failed to dial RPC handler for WebSocket server; It may not be running. See `twitch event websocket --help` for help on starting the WebSocket server.\n" +
+					"Error: " + err.Error(),
+			)
 		}
 
 		var reply rpc_handler.RPCResponse


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Closes #309 

## Description of Changes: 

- Updated error message to "Failed to dial RPC handler for WebSocket server; It may not be running. See `twitch event websocket --help` for help on starting the WebSocket server."

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
