### PR TITLE
Fixed issue where no scopes message was saying user id instead of scopes

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -122,7 +122,7 @@ func loginCmdRun(cmd *cobra.Command, args []string) error {
 		lightYellow("Expires In: %v\n", white("%v (%v)", strconv.FormatInt(r.ExpiresIn, 10), expiresInTimestamp))
 
 		if len(r.Scopes) == 0 {
-			lightYellow("User ID: %v\n", white("None"))
+			lightYellow("Scopes: %v\n", white("None"))
 		} else {
 			lightYellow("Scopes:\n")
 			for _, s := range r.Scopes {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Description of Changes: 

- Fixed small issue with `twitch token --validate` which showed "User ID: None" instead of "Scopes: None" when there was no scopes.

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)
