### PR TITLE
Fixes #329

### DIFF
--- a/cmd/events/retrigger.go
+++ b/cmd/events/retrigger.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	configure_event "github.com/twitchdev/twitch-cli/internal/events/configure"
 	"github.com/twitchdev/twitch-cli/internal/events/trigger"

--- a/cmd/events/retrigger.go
+++ b/cmd/events/retrigger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	configure_event "github.com/twitchdev/twitch-cli/internal/events/configure"
 	"github.com/twitchdev/twitch-cli/internal/events/trigger"
@@ -19,7 +20,7 @@ func RetriggerCommand() (command *cobra.Command) {
 	}
 
 	command.Flags().StringVarP(&forwardAddress, "forward-address", "F", "", "Forward address for mock event (webhook only).")
-	command.Flags().StringVarP(&eventID, "id", "i", "", "ID of the event to be refired.")
+	command.Flags().StringVarP(&eventMessageID, "id", "i", "", "ID of the event to be refired.")
 	command.Flags().StringVarP(&secret, "secret", "s", "", "Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC and must be 10-100 characters in length.")
 	command.Flags().BoolVarP(&noConfig, "no-config", "D", false, "Disables the use of the configuration, if it exists.")
 	command.MarkFlagRequired("id")
@@ -49,7 +50,8 @@ func retriggerCmdRun(cmd *cobra.Command, args []string) error {
 		forwardAddress = defaults.ForwardAddress
 	}
 
-	res, err := trigger.RefireEvent(eventID, trigger.TriggerParameters{
+	//color.New().Add(color.FgGreen).Println(fmt.Sprintf(`Refire %v`, eventMessageID));
+	res, err := trigger.RefireEvent(eventMessageID, trigger.TriggerParameters{
 		ForwardAddress: forwardAddress,
 		Secret:         secret,
 		Timestamp:      util.GetTimestamp().Format(time.RFC3339Nano),

--- a/cmd/events/trigger.go
+++ b/cmd/events/trigger.go
@@ -47,7 +47,7 @@ func TriggerCommand() (command *cobra.Command) {
 	command.Flags().StringVarP(&description, "description", "d", "", "Title the stream should be updated with.")
 	command.Flags().StringVarP(&gameID, "game-id", "G", "", "Sets the game/category ID for applicable events.")
 	command.Flags().StringVarP(&tier, "tier", "", "", "Sets the subscription tier. Valid values are 1000, 2000, and 3000.")
-	command.Flags().StringVarP(&eventID, "subscription-id", "u", "", "Manually set the subscription/event ID of the event itself.")
+	command.Flags().StringVarP(&subscriptionID, "subscription-id", "u", "", "Manually set the subscription/event ID of the event itself.")
 	command.Flags().StringVarP(&eventMessageID, "event-id", "I", "", "Manually set the Twitch-Eventsub-Message-Id header value for the event.")
 	command.Flags().StringVar(&timestamp, "timestamp", "", "Sets the timestamp to be used in payloads and headers. Must be in RFC3339Nano format.")
 	command.Flags().IntVar(&charityCurrentValue, "charity-current-value", 0, "Only used for \"charity-*\" events. Manually set the current dollar value for charity events.")
@@ -94,7 +94,7 @@ func triggerCmdRun(cmd *cobra.Command, args []string) error {
 	for i := 0; i < count; i++ {
 		res, err := trigger.Fire(trigger.TriggerParameters{
 			Event:               args[0],
-			EventID:             eventID,
+			SubscriptionID:      subscriptionID,
 			EventMessageID:      eventMessageID,
 			Transport:           transport,
 			ForwardAddress:      forwardAddress,

--- a/cmd/events/variables.go
+++ b/cmd/events/variables.go
@@ -10,7 +10,7 @@ var (
 	fromUser            string
 	toUser              string
 	giftUser            string
-	eventID             string
+	subscriptionID      string
 	eventMessageID      string
 	secret              string
 	eventStatus         string

--- a/cmd/events/verify_subscription.go
+++ b/cmd/events/verify_subscription.go
@@ -33,7 +33,7 @@ func VerifySubscriptionCommand() (command *cobra.Command) {
 	command.Flags().StringVarP(&transport, "transport", "T", "webhook", fmt.Sprintf("Preferred transport method for event. Defaults to EventSub.\nSupported values: %s", events.ValidTransports()))
 	command.Flags().StringVarP(&secret, "secret", "s", "", "Webhook secret. If defined, signs all forwarded events with the SHA256 HMAC and must be 10-100 characters in length.")
 	command.Flags().StringVar(&timestamp, "timestamp", "", "Sets the timestamp to be used in payloads and headers. Must be in RFC3339Nano format.")
-	command.Flags().StringVarP(&eventID, "subscription-id", "u", "", "Manually set the subscription/event ID of the event itself.")
+	command.Flags().StringVarP(&subscriptionID, "subscription-id", "u", "", "Manually set the subscription/event ID of the event itself.")
 	command.Flags().StringVarP(&eventMessageID, "event-id", "I", "", "Manually set the Twitch-Eventsub-Message-Id header value for the event.")
 	command.Flags().StringVarP(&version, "version", "v", "", "Chooses the EventSub version used for a specific event. Not required for most events.")
 	command.Flags().BoolVarP(&noConfig, "no-config", "D", false, "Disables the use of the configuration, if it exists.")
@@ -91,8 +91,8 @@ https://dev.twitch.tv/docs/eventsub/handling-webhook-events#processing-an-event`
 		ForwardAddress:    forwardAddress,
 		Secret:            secret,
 		Timestamp:         timestamp,
-		EventID:           eventID,
 		EventMessageID:    eventMessageID,
+		SubscriptionID:    subscriptionID,
 		BroadcasterUserID: toUser,
 		Version:           version,
 	})

--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -5,7 +5,8 @@ package events
 // MockEventParameters are used to craft the event; most of this data is prepopulated by lower services, such as the from/to users to avoid
 // replicating logic across files
 type MockEventParameters struct {
-	ID                  string
+	EventMessageID      string
+	SubscriptionID      string
 	Transport           string
 	Trigger             string
 	FromUserID          string

--- a/internal/events/trigger/forward_event.go
+++ b/internal/events/trigger/forward_event.go
@@ -68,7 +68,7 @@ func ForwardEvent(p ForwardParamters) (*http.Response, error) {
 
 	switch p.Transport {
 	case models.TransportWebhook:
-		req.Header.Set("Twitch-Eventsub-Message-Id", p.EventMessageID)
+		req.Header.Set("Twitch-Eventsub-Message-Id", p.ID)
 		req.Header.Set("Twitch-Eventsub-Subscription-Type", p.Event)
 		req.Header.Set("Twitch-Eventsub-Subscription-Version", p.SubscriptionVersion)
 		switch p.Type {

--- a/internal/events/trigger/retrigger_event_test.go
+++ b/internal/events/trigger/retrigger_event_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/twitchdev/twitch-cli/internal/models"
 	"github.com/twitchdev/twitch-cli/test_setup"
+	"github.com/twitchdev/twitch-cli/internal/util"
 )
 
 func TestRefireEvent(t *testing.T) {
@@ -24,8 +25,11 @@ func TestRefireEvent(t *testing.T) {
 	}))
 	defer ts.Close()
 
+	var eventMessageID = util.RandomGUID();
+
 	params := TriggerParameters{
 		Event:          "gift",
+		EventMessageID: eventMessageID,
 		Transport:      models.TransportWebhook,
 		IsAnonymous:    false,
 		FromUser:       "",
@@ -47,7 +51,7 @@ func TestRefireEvent(t *testing.T) {
 	err = json.Unmarshal([]byte(response), &body)
 	a.Nil(err)
 
-	json, err := RefireEvent(body.Subscription.ID, params)
+	json, err := RefireEvent(eventMessageID, params)
 	a.Nil(err)
 	a.Equal(response, json)
 }

--- a/internal/events/trigger/retrigger_event_test.go
+++ b/internal/events/trigger/retrigger_event_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/twitchdev/twitch-cli/internal/models"
 	"github.com/twitchdev/twitch-cli/test_setup"
-	"github.com/twitchdev/twitch-cli/internal/util"
 )
 
 func TestRefireEvent(t *testing.T) {
@@ -25,7 +24,7 @@ func TestRefireEvent(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	var eventMessageID = util.RandomGUID();
+	var eventMessageID = "testtriggereventid";
 
 	params := TriggerParameters{
 		Event:          "gift",

--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -42,7 +42,7 @@ type TriggerParameters struct {
 	GameID              string
 	Tier                string
 	Timestamp           string
-	EventID             string
+	SubscriptionID      string
 	EventMessageID      string
 	CharityCurrentValue int
 	CharityTargetValue  int
@@ -99,8 +99,14 @@ func Fire(p TriggerParameters) (string, error) {
 				"Valid values are 1000, 2000 or 3000")
 	}
 
+	// the header twitch-eventsub-message-id
 	if p.EventMessageID == "" {
 		p.EventMessageID = util.RandomGUID()
+	}
+
+	// the body subscription.id
+	if p.SubscriptionID == "" {
+		p.SubscriptionID = util.RandomGUID()
 	}
 
 	if p.Timestamp == "" {
@@ -117,7 +123,8 @@ https://dev.twitch.tv/docs/eventsub/handling-webhook-events#processing-an-event`
 	}
 
 	eventParamaters := events.MockEventParameters{
-		ID:                  p.EventID,
+		SubscriptionID:      p.SubscriptionID,
+		EventMessageID:      p.EventMessageID,
 		Trigger:             p.Event,
 		Transport:           p.Transport,
 		FromUserID:          p.FromUser,
@@ -162,6 +169,7 @@ https://dev.twitch.tv/docs/eventsub/handling-webhook-events#processing-an-event`
 		return "", err
 	}
 
+	//color.New().Add(color.FgGreen).Println(fmt.Sprintf(`Insert into DB with %v`, resp.ID));
 	err = db.NewQuery(nil, 100).InsertIntoDB(database.EventCacheParameters{
 		ID:        resp.ID,
 		Event:     p.Event,

--- a/internal/events/types/_template/_event_name.go
+++ b/internal/events/types/_template/_event_name.go
@@ -62,7 +62,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/ad_break/ad_break_begin.go
+++ b/internal/events/types/ad_break/ad_break_begin.go
@@ -37,7 +37,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -89,7 +89,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/authorization_grant/grant.go
+++ b/internal/events/types/authorization_grant/grant.go
@@ -33,7 +33,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook:
 		body := &models.AuthorizationRevokeEventSubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -79,7 +79,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/authorization_revoke/revoke.go
+++ b/internal/events/types/authorization_revoke/revoke.go
@@ -36,7 +36,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := &models.AuthorizationRevokeEventSubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -87,7 +87,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/ban/ban.go
+++ b/internal/events/types/ban/ban.go
@@ -110,7 +110,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 
 		body := models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -152,7 +152,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/channel_points_redemption/redemption_event.go
+++ b/internal/events/types/channel_points_redemption/redemption_event.go
@@ -55,7 +55,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := models.RedemptionEventSubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -70,7 +70,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				CreatedAt: params.Timestamp,
 			},
 			Event: models.RedemptionEventSubEvent{
-				ID:                   params.ID,
+				ID:                   util.RandomGUID(),
 				BroadcasterUserID:    params.ToUserID,
 				BroadcasterUserLogin: params.ToUserName,
 				BroadcasterUserName:  params.ToUserName,
@@ -114,7 +114,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/channel_points_reward/reward_event.go
+++ b/internal/events/types/channel_points_reward/reward_event.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/twitchdev/twitch-cli/internal/events"
 	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
 )
 
 var transportsSupported = map[string]bool{
@@ -48,7 +49,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -63,7 +64,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				CreatedAt: params.Timestamp,
 			},
 			Event: models.RewardEventSubEvent{
-				ID:                                params.ID,
+				ID:                                util.RandomGUID(),
 				BroadcasterUserID:                 params.ToUserID,
 				BroadcasterUserLogin:              params.ToUserName,
 				BroadcasterUserName:               params.ToUserName,
@@ -128,7 +129,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.ToUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/channel_update_v1/channel_update.go
+++ b/internal/events/types/channel_update_v1/channel_update.go
@@ -49,7 +49,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 		body := &models.EventsubResponse{
 			// make the eventsub response (if supported)
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -99,7 +99,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/channel_update_v2/channel_update.go
+++ b/internal/events/types/channel_update_v2/channel_update.go
@@ -49,7 +49,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 		body := &models.EventsubResponse{
 			// make the eventsub response (if supported)
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -102,7 +102,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/charity/charity_event.go
+++ b/internal/events/types/charity/charity_event.go
@@ -139,7 +139,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
 				Status:  params.SubscriptionStatus,
@@ -199,7 +199,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:     params.ID,
+		ID:     params.EventMessageID,
 		JSON:   event,
 		ToUser: params.ToUserID,
 	}, nil

--- a/internal/events/types/cheer/cheer_event.go
+++ b/internal/events/types/cheer/cheer_event.go
@@ -45,7 +45,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -97,7 +97,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/drop/drop.go
+++ b/internal/events/types/drop/drop.go
@@ -78,7 +78,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 		}
 		body := &models.DropsEntitlementEventSubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -121,7 +121,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/extension_transaction/transaction_event.go
+++ b/internal/events/types/extension_transaction/transaction_event.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/twitchdev/twitch-cli/internal/events"
 	"github.com/twitchdev/twitch-cli/internal/models"
+	"github.com/twitchdev/twitch-cli/internal/util"
 )
 
 var transportsSupported = map[string]bool{
@@ -44,7 +45,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook:
 		body := &models.TransactionEventSubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -59,7 +60,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				CreatedAt: params.Timestamp,
 			},
 			Event: models.TransactionEventSubEvent{
-				ID:                   params.ID,
+				ID:                   util.RandomGUID(),
 				ExtensionClientID:    params.ClientID,
 				BroadcasterUserID:    params.ToUserID,
 				BroadcasterUserLogin: "testBroadcaster",
@@ -100,7 +101,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/follow/follow_event.go
+++ b/internal/events/types/follow/follow_event.go
@@ -35,7 +35,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -86,7 +86,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/gift/channel_gift.go
+++ b/internal/events/types/gift/channel_gift.go
@@ -48,7 +48,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := &models.GiftEventSubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -103,7 +103,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/goal/goal_event.go
+++ b/internal/events/types/goal/goal_event.go
@@ -71,7 +71,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 
 		body := models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -86,7 +86,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				CreatedAt: params.Timestamp,
 			},
 			Event: models.GoalEventSubEvent{
-				ID:                   params.ID,
+				ID:                   util.RandomGUID(),
 				BroadcasterUserID:    params.ToUserID,
 				BroadcasterUserLogin: params.ToUserName,
 				BroadcasterUserName:  params.ToUserName,
@@ -125,7 +125,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/hype_train/hype_train_event.go
+++ b/internal/events/types/hype_train/hype_train_event.go
@@ -51,7 +51,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := models.HypeTrainEventSubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -66,7 +66,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				CreatedAt: params.Timestamp,
 			},
 			Event: models.HypeTrainEventSubEvent{
-				ID:                   params.ID,
+				ID:                   util.RandomGUID(),
 				BroadcasterUserID:    params.ToUserID,
 				BroadcasterUserLogin: params.ToUserName,
 				BroadcasterUserName:  params.ToUserName,
@@ -136,7 +136,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 		return events.MockEventResponse{}, nil
 	}
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/moderator_change/moderator_change_event.go
+++ b/internal/events/types/moderator_change/moderator_change_event.go
@@ -39,7 +39,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -88,7 +88,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/poll/poll.go
+++ b/internal/events/types/poll/poll.go
@@ -61,7 +61,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 
 		body := &models.PollEventSubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -128,7 +128,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/prediction/prediction.go
+++ b/internal/events/types/prediction/prediction.go
@@ -92,7 +92,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 
 		body := &models.PredictionEventSubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -154,7 +154,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/raid/raid.go
+++ b/internal/events/types/raid/raid.go
@@ -37,7 +37,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := &models.RaidEventSubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -86,7 +86,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/shield_mode/shield_mode.go
+++ b/internal/events/types/shield_mode/shield_mode.go
@@ -54,7 +54,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 
 		body := models.ShieldModeEventSubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -97,7 +97,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		ToUser:   params.ToUserID,
 		FromUser: params.FromUserID,

--- a/internal/events/types/shoutout/shoutout.go
+++ b/internal/events/types/shoutout/shoutout.go
@@ -45,7 +45,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 		if params.Trigger == "shoutout-create" {
 			body := models.ShoutoutCreateEventSubResponse{
 				Subscription: models.EventsubSubscription{
-					ID:      params.ID,
+					ID:      params.SubscriptionID,
 					Status:  params.SubscriptionStatus,
 					Type:    triggerMapping[params.Transport][params.Trigger],
 					Version: e.SubscriptionVersion(),
@@ -84,7 +84,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 		} else if params.Trigger == "shoutout-received" {
 			body := models.ShoutoutReceivedEventSubResponse{
 				Subscription: models.EventsubSubscription{
-					ID:      params.ID,
+					ID:      params.SubscriptionID,
 					Status:  params.SubscriptionStatus,
 					Type:    triggerMapping[params.Transport][params.Trigger],
 					Version: e.SubscriptionVersion(),
@@ -137,7 +137,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		ToUser:   params.ToUserID,
 		FromUser: params.FromUserID,

--- a/internal/events/types/streamdown/streamdown.go
+++ b/internal/events/types/streamdown/streamdown.go
@@ -36,7 +36,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := &models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -81,7 +81,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/streamup/streamup.go
+++ b/internal/events/types/streamup/streamup.go
@@ -45,7 +45,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := &models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -93,7 +93,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/subscribe/sub_event.go
+++ b/internal/events/types/subscribe/sub_event.go
@@ -51,7 +51,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := &models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -102,7 +102,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/subscription_message/subscription_message.go
+++ b/internal/events/types/subscription_message/subscription_message.go
@@ -41,7 +41,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := &models.SubscribeMessageEventSubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -107,7 +107,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/unban/unban.go
+++ b/internal/events/types/unban/unban.go
@@ -49,7 +49,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 
 		body := models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -91,7 +91,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:       params.ID,
+		ID:       params.EventMessageID,
 		JSON:     event,
 		FromUser: params.FromUserID,
 		ToUser:   params.ToUserID,

--- a/internal/events/types/unban_requests/unban_requests.go
+++ b/internal/events/types/unban_requests/unban_requests.go
@@ -75,7 +75,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
 				Status:  params.SubscriptionStatus,
@@ -118,7 +118,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:     params.ID,
+		ID:     params.EventMessageID,
 		JSON:   event,
 		ToUser: params.ToUserID,
 	}, nil

--- a/internal/events/types/user/user_update.go
+++ b/internal/events/types/user/user_update.go
@@ -35,7 +35,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	case models.TransportWebhook, models.TransportWebSocket:
 		body := models.EventsubResponse{
 			Subscription: models.EventsubSubscription{
-				ID:      params.ID,
+				ID:      params.SubscriptionID,
 				Status:  params.SubscriptionStatus,
 				Type:    triggerMapping[params.Transport][params.Trigger],
 				Version: e.SubscriptionVersion(),
@@ -84,7 +84,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 	}
 
 	return events.MockEventResponse{
-		ID:     params.ID,
+		ID:     params.EventMessageID,
 		JSON:   event,
 		ToUser: params.ToUserID,
 	}, nil


### PR DESCRIPTION
Complete the work in #322 as it broke things instead and fix #329

Testing verify trigger and retrigger (on the raid topic at least)

Notable faults/issues

Random ID usage on CP Reward add and TRN Event, this probably needs to be lifted to a field (seperate PR?)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

- #322 that was included in the latest release broke trigger/retrigger
- postbody.subscription.id is blank instead of populated
- header['twitch-eventsub-message-id'] is blank instead of populated, this was what 322 attempted to fix

## Description of Changes: 

- Percolate the work in #322 so it's actually used properly _across_ all types supported
- itemID of reward_event.go and transaction_event.go in types used a random RandomGUID at the moment

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
