### PR TITLE
FIXED #331: mock event websocket server ignores a valid 'session'

### DIFF
--- a/internal/events/websocket/mock_server/server.go
+++ b/internal/events/websocket/mock_server/server.go
@@ -409,7 +409,7 @@ func (ws *WebSocketServer) HandleRPCEventSubForwarding(eventsubBody string, clie
 	didSend := false
 
 	for _, client := range ws.Clients.All() {
-		if clientName != "" && !strings.EqualFold(strings.ToLower(clientName), clientName) {
+		if clientName != "" && !strings.EqualFold(strings.ToLower(clientName), client.clientName) {
 			// When --session is used, only send to that client
 			continue
 		}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

#331 mock event websocket server ignores a valid 'session'

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
