### PR TITLE
Buffered channel so vscode stops complaining and perhaps it saves a b…

### DIFF
--- a/internal/events/websocket/mock_server/manager.go
+++ b/internal/events/websocket/mock_server/manager.go
@@ -71,7 +71,7 @@ func StartWebsocketServer(enableDebug bool, ip string, port int, enableSSL bool,
 	serverManager.primaryServer = initialServer.ServerId
 
 	// Allow exit with Ctrl + C
-	stop := make(chan os.Signal)
+	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt)
 
 	m := http.NewServeMux()


### PR DESCRIPTION
…it of memory

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Buffered channel so vscode stops complaining and perhaps it saves a bit of memory

## Description of Changes: 

- Set the number of elements that can be sent to the channel without the send blocking to 1 instead of the default 0

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
