### PR TITLE
Use tier param for channel.subscription.gift event

### DIFF
--- a/internal/events/types/gift/channel_gift.go
+++ b/internal/events/types/gift/channel_gift.go
@@ -69,7 +69,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				BroadcasterUserID:    params.ToUserID,
 				BroadcasterUserLogin: params.ToUserName,
 				BroadcasterUserName:  params.ToUserName,
-				Tier:                 "1000",
+				Tier:                 params.Tier,
 				Total:                int(params.Cost),
 				CumulativeTotal:      &total,
 				IsAnonymous:          params.IsAnonymous,


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Fixes #340, the channel.subscription.gift had its tier hardcoded to `1000` rather than using the value set in `params.tier`.

## Description of Changes: 

- Removed the hardcoded tier from the channel.subscription.gift event

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
