### PR TITLE
Only log read error when WebSocket connection was closed unexpectedly

### DIFF
--- a/internal/events/websocket/mock_server/server.go
+++ b/internal/events/websocket/mock_server/server.go
@@ -251,7 +251,9 @@ func (ws *WebSocketServer) WsPageHandler(w http.ResponseWriter, r *http.Request)
 
 		mt, message, err := conn.ReadMessage()
 		if err != nil && ws.Status != 0 { // If server is shut down, clients should already be disconnectd.
-			log.Printf("read err [%v]: %v", client.clientName, err)
+			if _, ok := err.(*websocket.CloseError); !ok || websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure) {
+				log.Printf("read err [%v]: %v", client.clientName, err)
+			}
 
 			ws.muClients.Lock()
 			client.CloseWithReason(closeClientDisconnected)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Currently logs on any WebSocket read error, normal closures also return a read error as you can't read from closed connections. These "normal closure" errors being logged can be confusing to some users

## Description of Changes: 

- Only log read error when WebSocket connection was closed unexpectedly

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
