### PR TITLE
Don't make data object an empty array on error

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -45,7 +45,6 @@ func NewRequest(method string, path string, queryParameters []string, body []byt
 
 	isExtensionsLiveEndpoint := false // https://github.com/twitchdev/twitch-cli/issues/157
 
-	data.Data = make([]interface{}, 0)
 	client, err := GetClientInformation()
 	if err != nil {
 		return fmt.Errorf("Error fetching client information: %v", err.Error())
@@ -186,7 +185,7 @@ func NewRequest(method string, path string, queryParameters []string, body []byt
 		runCounter++
 	}
 
-	if data.Data == nil {
+	if data.Data == nil && data.Error == "" {
 		data.Data = make([]interface{}, 0)
 	}
 	// handle json marshalling better; returns empty slice vs. null


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

Historically when the API returned an error the CLI would include a data array in the json response being printed out, however this data array is not returned from the api. 
API response
```
{
	"error": "Not Found",
	"message": "404: Not Found",
	"status": 404
}
```
CLI Output
```
{
	"data": [],
	"error": "Not Found",
	"message": "404: Not Found",
	"status": 404
}
```

## Description of Changes: 

- Don't initialize an array when data is nil and there is an error message

## Checklist

- [x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [x] I have self-reviewed the changes being requested
- [x] I have made comments on pieces of code that may be difficult to understand for other editors
- [x] I have updated the documentation (if applicable)
