### PR TITLE
Add User Input variable for channel point event

### DIFF
--- a/cmd/events/trigger.go
+++ b/cmd/events/trigger.go
@@ -57,6 +57,7 @@ func TriggerCommand() (command *cobra.Command) {
 	command.Flags().StringVar(&websocketClient, "session", "", "Defines a specific websocket client/session to forward an event to. Used only with \"websocket\" transport.")
 	command.Flags().StringVar(&banStart, "ban-start", "", "Sets the timestamp a ban started at.")
 	command.Flags().StringVar(&banEnd, "ban-end", "", "Sets the timestamp a ban is intended to end at. If not set, the ban event will appear as permanent. This flag can take a timestamp or relative time (600, 600s, 10d4h12m55s)")
+	command.Flags().StringVar(&userInput, "user-input", "", "Sets the user input used for the event. Only applies to channel point redemptions.")
 
 	return
 }
@@ -119,6 +120,7 @@ func triggerCmdRun(cmd *cobra.Command, args []string) error {
 			WebSocketClient:     websocketClient,
 			BanStartTimestamp:   banStart,
 			BanEndTimestamp:     banEnd,
+			UserInput:           userInput,
 		})
 
 		if err != nil {

--- a/cmd/events/variables.go
+++ b/cmd/events/variables.go
@@ -30,4 +30,5 @@ var (
 	websocketClient     string
 	banStart            string
 	banEnd              string
+	userInput           string
 )

--- a/docs/event.md
+++ b/docs/event.md
@@ -115,6 +115,7 @@ This command can take either the Event or Alias listed as an argument. It is pre
 | `--timestamp`             |           | Sets the timestamp to be used in payloads and headers. Must be in RFC3339Nano format.                                           | `--timestamp 2017-04-13T14:34:23`            | N               |
 | `--to-user`               | `-t`      | Denotes the receiver's TUID of the event, usually the broadcaster.                                                              | `-t 44635596`                                | N               |
 | `--transport`             | `-T`      | The method used to send events. Can either be `webhook` or `websocket`. Default is `webhook`.                                   | `-T webhook`                                 | N               |
+| `--user-input`            |           | Sets the user input used for the event. Only applies to channel point redemptions.                                              | `--user-input Awesome redemption!`           | N               |
 
 **Examples**
 

--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -30,6 +30,7 @@ type MockEventParameters struct {
 	ClientID            string
 	BanStartTimestamp   string
 	BanEndTimestamp     string
+	UserInput           string
 }
 
 type MockEventResponse struct {

--- a/internal/events/trigger/trigger_event.go
+++ b/internal/events/trigger/trigger_event.go
@@ -51,6 +51,7 @@ type TriggerParameters struct {
 	WebSocketClient     string
 	BanStartTimestamp   string
 	BanEndTimestamp     string
+	UserInput           string
 }
 
 type TriggerResponse struct {
@@ -147,6 +148,7 @@ https://dev.twitch.tv/docs/eventsub/handling-webhook-events#processing-an-event`
 		GiftUser:            p.GiftUser,
 		BanStartTimestamp:   p.BanStartTimestamp,
 		BanEndTimestamp:     p.BanEndTimestamp,
+		UserInput:           p.UserInput,
 	}
 
 	e, err := types.GetByTriggerAndTransportAndVersion(p.Event, p.Transport, p.Version)

--- a/internal/events/types/channel_points_redemption/redemption_event.go
+++ b/internal/events/types/channel_points_redemption/redemption_event.go
@@ -77,7 +77,7 @@ func (e Event) GenerateEvent(params events.MockEventParameters) (events.MockEven
 				UserID:               params.FromUserID,
 				UserLogin:            params.FromUserName,
 				UserName:             params.FromUserName,
-				UserInput:            "Test Input From CLI",
+				UserInput:            params.UserInput,
 				Status:               params.EventStatus,
 				Reward: models.RedemptionReward{
 					ID:     params.ItemID,

--- a/internal/events/types/channel_points_redemption/redemption_event_test.go
+++ b/internal/events/types/channel_points_redemption/redemption_event_test.go
@@ -27,6 +27,7 @@ func TestEventSub(t *testing.T) {
 		ItemID:             "12345678-1234-abcd-5678-000000000000",
 		Cost:               1337,
 		ItemName:           "Testing",
+		UserInput:          "testing",
 	}
 
 	r, err := Event{}.GenerateEvent(params)
@@ -42,6 +43,7 @@ func TestEventSub(t *testing.T) {
 	a.Equal(params.Cost, body.Event.Reward.Cost)
 	a.Equal(params.ItemID, body.Event.Reward.ID)
 	a.Equal(params.ItemName, body.Event.Reward.Title)
+	a.Equal(params.UserInput, body.Event.UserInput)
 
 	params = events.MockEventParameters{
 		Transport:  models.TransportWebhook,


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature
Fixes the inability to supply the user input field for the channel point redemption event.

## Description of Changes: 

Adds a --user-input flag for the channel point redemption event to test with specific user prompts.

## Checklist

- [ x] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [ x] I have self-reviewed the changes being requested
- [ x] I have made comments on pieces of code that may be difficult to understand for other editors
- [ x] I have updated the documentation (if applicable)
