### PR TITLE
Prevent CORS from blocking DELETE in mock-api server

### DIFF
--- a/internal/mock_api/mock_server/server.go
+++ b/internal/mock_api/mock_server/server.go
@@ -122,6 +122,7 @@ func loggerMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Headers", "*")
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE")
 
 		if r.Method == "OPTIONS" {
 			w.WriteHeader(200)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Problem/Feature

The DELETE (and I assume PATCH and PUT) request methods are being blocked by CORS in the mock server:

```
Access to XMLHttpRequest at 'http://localhost:8080/mock/channel_points/custom_rewards?broadcaster_id=XXXX&id=XXXX'
from origin 'http://localhost' has been blocked by CORS policy:
Method DELETE is not allowed by Access-Control-Allow-Methods in preflight response.
```

## Description of Changes: 

- Set the additional HTTP methods in a header in the mock-api server
- This is the same Access-Control-Allow-Methods list from the websocket server (internal/events/websocket/mock_server/manager.go)

## Checklist

- [X] My code follows the [Contribution Guide](https://github.com/twitchdev/twitch-cli/blob/master/CONTRIBUTING.md#Requirements)
- [X] I have self-reviewed the changes being requested
- [X] I have made comments on pieces of code that may be difficult to understand for other editors
- [X] I have updated the documentation (if applicable)